### PR TITLE
Render display names of users and rooms according to the spec - take 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ else ( CMAKE_VERSION VERSION_LESS "3.1" )
     target_compile_features(qmatrixclient PRIVATE cxx_lambdas)
     target_compile_features(qmatrixclient PRIVATE cxx_auto_type)
     target_compile_features(qmatrixclient PRIVATE cxx_generalized_initializers)
+    target_compile_features(qmatrixclient PRIVATE cxx_nullptr)
 endif ( CMAKE_VERSION VERSION_LESS "3.1" )
 
 target_link_libraries(qmatrixclient Qt5::Core Qt5::Network Qt5::Gui)

--- a/connectionprivate.h
+++ b/connectionprivate.h
@@ -47,6 +47,8 @@ namespace QMatrixClient
 
             void processState( State* state );
             void processRooms( const QList<SyncRoomData>& data );
+            /** Finds a room with this id or creates a new one and adds it to roomMap. */
+            Room* provideRoom( QString id );
 
             Connection* q;
             ConnectionData* data;

--- a/room.cpp
+++ b/room.cpp
@@ -59,6 +59,7 @@ class Room::Private: public QObject
         int notificationCount;
         QList<User*> users;
         QList<User*> usersTyping;
+        QList<User*> membersLeft;
         QHash<User*, QString> lastReadEvent;
         QString prevBatch;
         bool gettingNewContent;
@@ -192,6 +193,11 @@ if( d->highlightCount == 0 )
 QList< User* > Room::usersTyping() const
 {
     return d->usersTyping;
+}
+
+QList< User* > Room::membersLeft() const
+{
+    return d->membersLeft;
 }
 
 QList< User* > Room::users() const
@@ -336,6 +342,8 @@ void Room::processStateEvent(Event* event)
                  and d->users.contains(u) )
         {
             d->users.removeAll(u);
+            if ( !d->membersLeft.contains(u) )
+                d->membersLeft.append(u);
             emit userRemoved(u);
         }
     }

--- a/room.cpp
+++ b/room.cpp
@@ -73,9 +73,9 @@ class Room::Private: public QObject
         // operation.
         //void inviteUser(User* u); // We might get it at some point in time.
         void addMember(User* u);
-        bool hasMember(User* u);
+        bool hasMember(User* u) const;
         // You can't identify a single user by displayname, only by id
-        User* member(QString id);
+        User* member(QString id) const;
         void renameMember(User* u, QString oldName);
         void removeMember(User* u);
 };
@@ -229,12 +229,12 @@ void Room::Private::addMember(User *u)
     }
 }
 
-bool Room::Private::hasMember(User* u)
+bool Room::Private::hasMember(User* u) const
 {
     return membersMap.values(u->name()).contains(u);
 }
 
-User* Room::Private::member(QString id)
+User* Room::Private::member(QString id) const
 {
     User* u = connection->user(id);
     return hasMember(u) ? u : nullptr;

--- a/room.h
+++ b/room.h
@@ -68,6 +68,7 @@ namespace QMatrixClient
 
         public slots:
             void getPreviousContent();
+            void memberRenamed(User* user, QString oldName);
 
         signals:
             void newMessage(Event* event);

--- a/room.h
+++ b/room.h
@@ -78,7 +78,13 @@ namespace QMatrixClient
 
         signals:
             void newMessage(Event* event);
+            /**
+             * Triggered when the room name, canonical alias or other aliases
+             * change. Not triggered when displayname changes.
+             */
             void namesChanged(Room* room);
+            /** Triggered only for changes in the room displayname. */
+            void displaynameChanged(Room* room);
             void topicChanged();
             void userAdded(User* user);
             void userRemoved(User* user);

--- a/room.h
+++ b/room.h
@@ -53,6 +53,12 @@ namespace QMatrixClient
 
             Q_INVOKABLE QList<User*> users() const;
 
+            /**
+             * @brief Produces a disambiguated name for a given user in
+             * the context of the room.
+             */
+            Q_INVOKABLE QString roomMembername(User* u) const;
+
             Q_INVOKABLE void addMessage( Event* event );
             Q_INVOKABLE void addInitialState( State* state );
             Q_INVOKABLE void updateData( const SyncRoomData& data );

--- a/room.h
+++ b/room.h
@@ -74,7 +74,7 @@ namespace QMatrixClient
 
         public slots:
             void getPreviousContent();
-            void memberRenamed(User* user, QString oldName);
+            void userRenamed(User* user, QString oldName);
 
         signals:
             void newMessage(Event* event);
@@ -88,6 +88,7 @@ namespace QMatrixClient
             void topicChanged();
             void userAdded(User* user);
             void userRemoved(User* user);
+            void memberRenamed(User* user);
             void joinStateChanged(JoinState oldState, JoinState newState);
             void typingChanged();
             void highlightCountChanged(Room* room);

--- a/room.h
+++ b/room.h
@@ -49,6 +49,7 @@ namespace QMatrixClient
             Q_INVOKABLE QString topic() const;
             Q_INVOKABLE JoinState joinState() const;
             Q_INVOKABLE QList<User*> usersTyping() const;
+            QList<User*> membersLeft() const;
 
             Q_INVOKABLE QList<User*> users() const;
 

--- a/user.cpp
+++ b/user.cpp
@@ -114,8 +114,9 @@ void User::processEvent(Event* event)
         RoomMemberEvent* e = static_cast<RoomMemberEvent*>(event);
         if( d->name != e->displayName() )
         {
+            const auto oldName = d->name;
             d->name = e->displayName();
-            emit nameChanged();
+            emit nameChanged(this, oldName);
         }
         if( d->avatarUrl != e->avatarUrl() )
         {

--- a/user.h
+++ b/user.h
@@ -56,7 +56,7 @@ namespace QMatrixClient
             void requestAvatar();
 
         signals:
-            void nameChanged();
+            void nameChanged(User*, QString);
             void avatarChanged(User* user);
 
         private:


### PR DESCRIPTION
Though it's yet incomplete (room names are on the way), I think you can start reviewing this. As you asked, I have split one big commit into smaller ones (and this is only the lib part, naturally). The code is backwards-compatible; however, I had to lay some leftovers for that - namely, User::displayname() and User::nameChanged(). Probably, they should be marked as deprecated in the /** docs */. I'll submit a separate PR on Quaternion later to reflect the newly introduced functionality in the UI.