### PR TITLE
Basejob improvement

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -63,7 +63,7 @@ void Connection::connectToServer(QString user, QString password)
 {
     PasswordLogin* loginJob = new PasswordLogin(d->data, user, password);
     connect( loginJob, &PasswordLogin::success, [=] () {
-        qDebug() << "Our user ID: " << d->userId;
+        qDebug() << "Our user ID: " << loginJob->id();
         connectWithToken(loginJob->id(), loginJob->token());
     });
     connect( loginJob, &PasswordLogin::failure, [=] () {

--- a/connectionprivate.cpp
+++ b/connectionprivate.cpp
@@ -116,67 +116,67 @@ Room* ConnectionPrivate::provideRoom(QString id)
     return room;
 }
 
-void ConnectionPrivate::connectDone(KJob* job)
-{
-    PasswordLogin* realJob = static_cast<PasswordLogin*>(job);
-    if( !realJob->error() )
-    {
-        isConnected = true;
-        userId = realJob->id();
-        qDebug() << "Our user ID: " << userId;
-        emit q->connected();
-    }
-    else {
-        emit q->loginError( job->errorString() );
-    }
-}
+//void ConnectionPrivate::connectDone(KJob* job)
+//{
+//    PasswordLogin* realJob = static_cast<PasswordLogin*>(job);
+//    if( !realJob->error() )
+//    {
+//        isConnected = true;
+//        userId = realJob->id();
+//        qDebug() << "Our user ID: " << userId;
+//        emit q->connected();
+//    }
+//    else {
+//        emit q->loginError( job->errorString() );
+//    }
+//}
 
-void ConnectionPrivate::reconnectDone(KJob* job)
-{
-    PasswordLogin* realJob = static_cast<PasswordLogin*>(job);
-    if( !realJob->error() )
-    {
-        userId = realJob->id();
-        emit q->reconnected();
-    }
-    else {
-        emit q->loginError( job->errorString() );
-        isConnected = false;
-    }
-}
+//void ConnectionPrivate::reconnectDone(KJob* job)
+//{
+//    PasswordLogin* realJob = static_cast<PasswordLogin*>(job);
+//    if( !realJob->error() )
+//    {
+//        userId = realJob->id();
+//        emit q->reconnected();
+//    }
+//    else {
+//        emit q->loginError( job->errorString() );
+//        isConnected = false;
+//    }
+//}
 
-void ConnectionPrivate::syncDone(KJob* job)
-{
-    SyncJob* syncJob = static_cast<SyncJob*>(job);
-    if( !syncJob->error() )
-    {
-        data->setLastEvent(syncJob->nextBatch());
-        processRooms(syncJob->roomData());
-        emit q->syncDone();
-    }
-    else {
-        if( syncJob->error() == BaseJob::NetworkError )
-            emit q->connectionError( syncJob->errorString() );
-        else
-            qDebug() << "syncJob failed, error:" << syncJob->error();
-    }
-}
+//void ConnectionPrivate::syncDone(KJob* job)
+//{
+//    SyncJob* syncJob = static_cast<SyncJob*>(job);
+//    if( !syncJob->error() )
+//    {
+//        data->setLastEvent(syncJob->nextBatch());
+//        processRooms(syncJob->roomData());
+//        emit q->syncDone();
+//    }
+//    else {
+//        if( syncJob->error() == BaseJob::NetworkError )
+//            emit q->connectionError( syncJob->errorString() );
+//        else
+//            qDebug() << "syncJob failed, error:" << syncJob->error();
+//    }
+//}
 
-void ConnectionPrivate::gotJoinRoom(KJob* job)
-{
-    qDebug() << "gotJoinRoom";
-    JoinRoomJob* joinJob = static_cast<JoinRoomJob*>(job);
-    if( !joinJob->error() )
-    {
-        if ( Room* r = provideRoom(joinJob->roomId()) )
-            emit q->joinedRoom(r);
-    }
-    else
-    {
-        if( joinJob->error() == BaseJob::NetworkError )
-            emit q->connectionError( joinJob->errorString() );
-    }
-}
+//void ConnectionPrivate::gotJoinRoom(KJob* job)
+//{
+//    qDebug() << "gotJoinRoom";
+//    JoinRoomJob* joinJob = static_cast<JoinRoomJob*>(job);
+//    if( !joinJob->error() )
+//    {
+//        if ( Room* r = provideRoom(joinJob->roomId()) )
+//            emit q->joinedRoom(r);
+//    }
+//    else
+//    {
+//        if( joinJob->error() == BaseJob::NetworkError )
+//            emit q->connectionError( joinJob->errorString() );
+//    }
+//}
 
 void ConnectionPrivate::gotRoomMembers(KJob* job)
 {

--- a/connectionprivate.h
+++ b/connectionprivate.h
@@ -60,10 +60,10 @@ namespace QMatrixClient
             QString userId;
 
         public slots:
-            void connectDone(KJob* job);
-            void reconnectDone(KJob* job);
-            void syncDone(KJob* job);
-            void gotJoinRoom(KJob* job);
+//            void connectDone(KJob* job);
+//            void reconnectDone(KJob* job);
+//            void syncDone(KJob* job);
+//            void gotJoinRoom(KJob* job);
             void gotRoomMembers(KJob* job);
     };
 }

--- a/jobs/basejob.cpp
+++ b/jobs/basejob.cpp
@@ -121,6 +121,7 @@ void BaseJob::fail(int errorCode, QString errorString)
     setErrorText( errorString );
     if( d->reply->isRunning() )
         d->reply->abort();
+    qWarning() << this << "failed:" << errorString;
     emitResult();
 }
 
@@ -138,7 +139,7 @@ void BaseJob::gotReply()
 {
     if( d->reply->error() != QNetworkReply::NoError )
     {
-        qDebug() << "NetworkError!!!" << d->reply->error();
+        qDebug() << "NetworkError:" << d->reply->error();
         fail( NetworkError, d->reply->errorString() );
         return;
     }

--- a/jobs/basejob.cpp
+++ b/jobs/basejob.cpp
@@ -42,6 +42,13 @@ class BaseJob::Private
 BaseJob::BaseJob(ConnectionData* connection, JobHttpType type, bool needsToken)
     : d(new Private(connection, type, needsToken))
 {
+    // Work around KJob inability to separate success and failure signals
+    connect(this, &BaseJob::result, [this]() {
+        if (error() == NoError)
+            emit success(this);
+        else
+            emit failure(this);
+    });
 }
 
 BaseJob::~BaseJob()

--- a/jobs/basejob.cpp
+++ b/jobs/basejob.cpp
@@ -54,7 +54,11 @@ BaseJob::BaseJob(ConnectionData* connection, JobHttpType type, bool needsToken)
 BaseJob::~BaseJob()
 {
     if( d->reply )
+    {
+        if( d->reply->isRunning() )
+            d->reply->abort();
         d->reply->deleteLater();
+    }
     delete d;
 }
 
@@ -115,6 +119,8 @@ void BaseJob::fail(int errorCode, QString errorString)
 {
     setError( errorCode );
     setErrorText( errorString );
+    if( d->reply->isRunning() )
+        d->reply->abort();
     emitResult();
 }
 
@@ -149,8 +155,7 @@ void BaseJob::gotReply()
 void BaseJob::timeout()
 {
     qDebug() << "Timeout!";
-    if( d->reply->isRunning() )
-        d->reply->abort();
+    fail( TimeoutError, "The job has timed out" );
 }
 
 void BaseJob::sslErrors(const QList<QSslError>& errors)

--- a/jobs/basejob.h
+++ b/jobs/basejob.h
@@ -45,7 +45,8 @@ namespace QMatrixClient
 
             void start() override;
 
-            enum ErrorCode { NetworkError = KJob::UserDefinedError, JsonParseError, UserDefinedError };
+            enum ErrorCode { NetworkError = KJob::UserDefinedError,
+                             JsonParseError, TimeoutError, UserDefinedError };
 
         signals:
             /**

--- a/jobs/basejob.h
+++ b/jobs/basejob.h
@@ -46,7 +46,18 @@ namespace QMatrixClient
             void start() override;
 
             enum ErrorCode { NetworkError = KJob::UserDefinedError, JsonParseError, UserDefinedError };
-            
+
+        signals:
+            /**
+             * Emitted together with KJob::result() but only if there's no error.
+             */
+            void success(BaseJob*);
+            /**
+             * Emitted together with KJob::result() if there's an error.
+             * Same as result(), this won't be emitted in case of kill(Quietly).
+             */
+            void failure(BaseJob*);
+
         protected:
             ConnectionData* connection() const;
 

--- a/room.cpp
+++ b/room.cpp
@@ -73,6 +73,7 @@ class Room::Private: public QObject
         QList<User*> membersLeft;
         QHash<User*, QString> lastReadEvent;
         QString prevBatch;
+        RoomMessagesJob* roomMessagesJob;
         bool gettingNewContent;
         
         // Convenience methods to work with the membersMap and usersLeft. addMember()
@@ -85,6 +86,8 @@ class Room::Private: public QObject
         User* member(QString id) const;
         void renameMember(User* u, QString oldName);
         void removeMember(User* u);
+
+        void getPreviousContent();
 
     private:
         QString calculateDisplayname() const;
@@ -100,7 +103,7 @@ Room::Room(Connection* connection, QString id)
     d->id = id;
     d->connection = connection;
     d->joinState = JoinState::Join;
-    d->gettingNewContent = false;
+    d->roomMessagesJob = nullptr;
     qDebug() << "New Room:" << id;
 
     //connection->getMembers(this); // I don't think we need this anymore in r0.0.1
@@ -373,31 +376,27 @@ void Room::updateData(const SyncRoomData& data)
 
 void Room::getPreviousContent()
 {
-    if( !d->gettingNewContent )
-    {
-        d->gettingNewContent = true;
-        RoomMessagesJob* job = d->connection->getMessages(this, d->prevBatch);
-        connect( job, &RoomMessagesJob::result, d, &Room::Private::gotMessages );
-    }
+    d->getPreviousContent();
 }
 
-void Room::Private::gotMessages(KJob* job)
+void Room::Private::getPreviousContent()
 {
-    RoomMessagesJob* realJob = static_cast<RoomMessagesJob*>(job);
-    if( realJob->error() )
+    if( !roomMessagesJob )
     {
-        qDebug() << realJob->errorString();
+        roomMessagesJob = connection->getMessages(q, prevBatch);
+        connect( roomMessagesJob, &RoomMessagesJob::result, [=]() {
+            if( !roomMessagesJob->error() )
+            {
+                for( Event* event: roomMessagesJob->events() )
+                {
+                    q->processMessageEvent(event);
+                    emit q->newMessage(event);
+                }
+                prevBatch = roomMessagesJob->end();
+            }
+            roomMessagesJob = nullptr;
+        });
     }
-    else
-    {
-        for( Event* event: realJob->events() )
-        {
-            q->processMessageEvent(event);
-            emit q->newMessage(event);
-        }
-        prevBatch = realJob->end();
-    }
-    gettingNewContent = false;
 }
 
 Connection* Room::connection()

--- a/room.cpp
+++ b/room.cpp
@@ -74,7 +74,6 @@ class Room::Private: public QObject
         QHash<User*, QString> lastReadEvent;
         QString prevBatch;
         RoomMessagesJob* roomMessagesJob;
-        bool gettingNewContent;
         
         // Convenience methods to work with the membersMap and usersLeft. addMember()
         // and removeMember() emit respective Room:: signals after a succesful

--- a/user.cpp
+++ b/user.cpp
@@ -28,7 +28,7 @@
 
 using namespace QMatrixClient;
 
-class User::Private: public QObject
+class User::Private
 {
     public:
         User* q;
@@ -45,8 +45,6 @@ class User::Private: public QObject
         QHash<QPair<int,int>,QPixmap> scaledMap;
 
         void requestAvatar();
-    public slots:
-        void gotAvatar(KJob* job);
 };
 
 User::User(QString userId, Connection* connection)
@@ -135,17 +133,12 @@ void User::Private::requestAvatar()
 {
     MediaThumbnailJob* job =
             connection->getThumbnail(avatarUrl, requestedWidth, requestedHeight);
-    connect( job, &MediaThumbnailJob::result, this, &User::Private::gotAvatar );
-}
-
-void User::Private::gotAvatar(KJob* job)
-{
-    avatarOngoingRequest = false;
-    avatarValid = true;
-    avatar =
-        static_cast<MediaThumbnailJob*>(job)->thumbnail()
-            .scaled(requestedWidth, requestedHeight,
-                    Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    scaledMap.clear();
-    emit q->avatarChanged(q);
+    connect( job, &MediaThumbnailJob::success, [=]() {
+        avatarOngoingRequest = false;
+        avatarValid = true;
+        avatar = job->thumbnail().scaled(requestedWidth, requestedHeight,
+                        Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        scaledMap.clear();
+        emit q->avatarChanged(q);
+    });
 }


### PR DESCRIPTION
So, I managed to get rid of KJob* pointers here and there - the solution basically consists of two parts (both quite simple):
1. Add two signals, BaseJob::success and BaseJob::failure, and have them triggered the first thing upon emitting KJob::result()
2. Instead of making separate result handling methods, put the job result handling next to its creation, using lambdas. The fact that lambdas can capture the local context, helps getting rid of using KJob* pointer in the signal - just by capturing the pointer to the actually created job (those [=] things do the trick, just in case).
And some code cleanup here and there, as usual.