### PR TITLE
Configurable job class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ set(libqmatrixclient_SRCS
    events/receiptevent.cpp
    events/unknownevent.cpp
    jobs/basejob.cpp
+   jobs/simplejob.cpp
    jobs/checkauthmethods.cpp
    jobs/passwordlogin.cpp
    jobs/postmessagejob.cpp

--- a/jobs/basejob.cpp
+++ b/jobs/basejob.cpp
@@ -39,7 +39,7 @@ class BaseJob::Private
         bool needsToken;
 };
 
-BaseJob::BaseJob(ConnectionData* connection, JobHttpType type, bool needsToken)
+BaseJob::BaseJob(ConnectionData* connection, JobHttpType type, QString name, bool needsToken)
     : d(new Private(connection, type, needsToken))
 {
     // Work around KJob inability to separate success and failure signals
@@ -49,6 +49,7 @@ BaseJob::BaseJob(ConnectionData* connection, JobHttpType type, bool needsToken)
         else
             emit failure(this);
     });
+    setObjectName(name);
 }
 
 BaseJob::~BaseJob()
@@ -121,7 +122,7 @@ void BaseJob::fail(int errorCode, QString errorString)
     setErrorText( errorString );
     if( d->reply->isRunning() )
         d->reply->abort();
-    qWarning() << this << "failed:" << errorString;
+    qWarning() << "Job" << objectName() << "failed:" << errorString;
     emitResult();
 }
 
@@ -155,7 +156,6 @@ void BaseJob::gotReply()
 
 void BaseJob::timeout()
 {
-    qDebug() << "Timeout!";
     fail( TimeoutError, "The job has timed out" );
 }
 

--- a/jobs/basejob.h
+++ b/jobs/basejob.h
@@ -40,7 +40,8 @@ namespace QMatrixClient
     {
             Q_OBJECT
         public:
-            BaseJob(ConnectionData* connection, JobHttpType type, bool needsToken=true);
+            BaseJob(ConnectionData* connection, JobHttpType type,
+                    QString name, bool needsToken=true);
             virtual ~BaseJob();
 
             void start() override;

--- a/jobs/checkauthmethods.cpp
+++ b/jobs/checkauthmethods.cpp
@@ -37,7 +37,7 @@ class CheckAuthMethods::Private
 };
 
 CheckAuthMethods::CheckAuthMethods(ConnectionData* connection)
-    : BaseJob(connection, JobHttpType::GetJob, false)
+    : BaseJob(connection, JobHttpType::GetJob, "CheckAuthMethods", false)
     , d(new Private)
 {
 }

--- a/jobs/joinroomjob.cpp
+++ b/jobs/joinroomjob.cpp
@@ -33,7 +33,7 @@ class JoinRoomJob::Private
 };
 
 JoinRoomJob::JoinRoomJob(ConnectionData* data, QString roomAlias)
-    : BaseJob(data, JobHttpType::PostJob)
+    : BaseJob(data, JobHttpType::PostJob, "JoinRoomJob")
     , d(new Private)
 {
     d->roomAlias = roomAlias;

--- a/jobs/leaveroomjob.cpp
+++ b/jobs/leaveroomjob.cpp
@@ -34,7 +34,7 @@ class LeaveRoomJob::Private
 };
 
 LeaveRoomJob::LeaveRoomJob(ConnectionData* data, Room* room)
-    : BaseJob(data, JobHttpType::PostJob)
+    : BaseJob(data, JobHttpType::PostJob, "LeaveRoomJob")
     , d(new Private(room))
 {
 }

--- a/jobs/mediathumbnailjob.cpp
+++ b/jobs/mediathumbnailjob.cpp
@@ -34,7 +34,7 @@ class MediaThumbnailJob::Private
 
 MediaThumbnailJob::MediaThumbnailJob(ConnectionData* data, QUrl url, int requestedWidth, int requestedHeight,
                                      ThumbnailType thumbnailType)
-    : BaseJob(data, JobHttpType::GetJob)
+    : BaseJob(data, JobHttpType::GetJob, "MediaThumbnailJob")
     , d(new Private)
 {
     d->url = url;

--- a/jobs/passwordlogin.cpp
+++ b/jobs/passwordlogin.cpp
@@ -39,7 +39,7 @@ class PasswordLogin::Private
 };
 
 PasswordLogin::PasswordLogin(ConnectionData* connection, QString user, QString password)
-    : BaseJob(connection, JobHttpType::PostJob, false)
+    : BaseJob(connection, JobHttpType::PostJob, "PasswordLogin", false)
     , d(new Private)
 {
     d->user = user;

--- a/jobs/passwordlogin.h
+++ b/jobs/passwordlogin.h
@@ -19,27 +19,25 @@
 #ifndef QMATRIXCLIENT_PASSWORDLOGIN_H
 #define QMATRIXCLIENT_PASSWORDLOGIN_H
 
-#include "basejob.h"
+#include "simplejob.h"
 
 namespace QMatrixClient
 {
     class ConnectionData;
 
-    class PasswordLogin : public BaseJob
+    class PasswordLogin : public SimpleJob
     {
-            Q_OBJECT
         public:
             PasswordLogin(ConnectionData* connection, QString user, QString password);
             virtual ~PasswordLogin();
 
-            QString token();
-            QString id();
-            QString server();
+            ResultItem<QString> token;
+            ResultItem<QString> id;
+            ResultItem<QString> server;
 
         protected:
-            QString apiPath();
-            QJsonObject data();
-            void parseJson(const QJsonDocument& data);
+            virtual QString apiPath() override;
+            virtual QJsonObject data() override;
 
         private:
             class Private;

--- a/jobs/postmessagejob.cpp
+++ b/jobs/postmessagejob.cpp
@@ -35,7 +35,7 @@ class PostMessageJob::Private
 };
 
 PostMessageJob::PostMessageJob(ConnectionData* connection, Room* room, QString type, QString message)
-    : BaseJob(connection, JobHttpType::PostJob)
+    : BaseJob(connection, JobHttpType::PostJob, "PostMessageJob")
     , d(new Private)
 {
     d->type = type;

--- a/jobs/postreceiptjob.cpp
+++ b/jobs/postreceiptjob.cpp
@@ -34,7 +34,7 @@ class PostReceiptJob::Private
 };
 
 PostReceiptJob::PostReceiptJob(ConnectionData* connection, QString roomId, QString eventId)
-    : BaseJob(connection, JobHttpType::PostJob)
+    : BaseJob(connection, JobHttpType::PostJob, "PostReceiptJob")
     , d(new Private)
 {
     d->roomId = roomId;

--- a/jobs/roommembersjob.cpp
+++ b/jobs/roommembersjob.cpp
@@ -34,7 +34,7 @@ class RoomMembersJob::Private
 };
 
 RoomMembersJob::RoomMembersJob(ConnectionData* data, Room* room)
-    : BaseJob(data, JobHttpType::GetJob)
+    : BaseJob(data, JobHttpType::GetJob, "RoomMembersJob")
     , d(new Private)
 {
     d->room = room;

--- a/jobs/roommessagesjob.cpp
+++ b/jobs/roommessagesjob.cpp
@@ -40,7 +40,7 @@ class RoomMessagesJob::Private
 };
 
 RoomMessagesJob::RoomMessagesJob(ConnectionData* data, Room* room, QString from, FetchDirectory dir, int limit)
-    : BaseJob(data, JobHttpType::GetJob)
+    : BaseJob(data, JobHttpType::GetJob, "RoomMessagesJob")
 {
     d = new Private();
     d->room = room;

--- a/jobs/roommessagesjob.cpp
+++ b/jobs/roommessagesjob.cpp
@@ -28,26 +28,19 @@ using namespace QMatrixClient;
 class RoomMessagesJob::Private
 {
     public:
-        Private() {}
-
         Room* room;
         QString from;
         FetchDirectory dir;
         int limit;
 
         QList<Event*> events;
-        QString end;
 };
 
 RoomMessagesJob::RoomMessagesJob(ConnectionData* data, Room* room, QString from, FetchDirectory dir, int limit)
-    : BaseJob(data, JobHttpType::GetJob, "RoomMessagesJob")
-{
-    d = new Private();
-    d->room = room;
-    d->from = from;
-    d->dir = dir;
-    d->limit = limit;
-}
+    : SimpleJob(data, JobHttpType::GetJob, "RoomMessagesJob")
+    , d(new Private{room, from, dir, limit, {} })
+    , end("end", *this)
+{ }
 
 RoomMessagesJob::~RoomMessagesJob()
 {
@@ -59,11 +52,6 @@ QList<Event*> RoomMessagesJob::events()
     return d->events;
 }
 
-QString RoomMessagesJob::end()
-{
-    return d->end;
-}
-
 QString RoomMessagesJob::apiPath()
 {
     return QString("/_matrix/client/r0/rooms/%1/messages").arg(d->room->id());
@@ -72,12 +60,11 @@ QString RoomMessagesJob::apiPath()
 QUrlQuery RoomMessagesJob::query()
 {
     QUrlQuery query;
-    query.addQueryItem("from", d->from);
-    if( d->dir == FetchDirectory::Backwards )
-        query.addQueryItem("dir", "b");
-    else
-        query.addQueryItem("dir", "f");
-    query.addQueryItem("limit", QString::number(d->limit));
+    query.setQueryItems({
+          { "from", d->from }
+        , { "limit", QString::number(d->limit) }
+        , { "dir", d->dir == FetchDirectory::Backwards ? "b" : "f" }
+    });
     return query;
 }
 
@@ -90,6 +77,5 @@ void RoomMessagesJob::parseJson(const QJsonDocument& data)
         Event* event = Event::fromJson(val.toObject());
         d->events.append(event);
     }
-    d->end = obj.value("end").toString();
-    emitResult();
+    SimpleJob::parseJson(data);
 }

--- a/jobs/roommessagesjob.h
+++ b/jobs/roommessagesjob.h
@@ -19,7 +19,7 @@
 #ifndef QMATRIXCLIENT_ROOMMESSAGESJOB_H
 #define QMATRIXCLIENT_ROOMMESSAGESJOB_H
 
-#include "basejob.h"
+#include "simplejob.h"
 
 namespace QMatrixClient
 {
@@ -28,7 +28,7 @@ namespace QMatrixClient
 
     enum class FetchDirectory { Backwards, Forward };
 
-    class RoomMessagesJob: public BaseJob
+    class RoomMessagesJob: public SimpleJob
     {
             Q_OBJECT
         public:
@@ -36,7 +36,7 @@ namespace QMatrixClient
             virtual ~RoomMessagesJob();
 
             QList<Event*> events();
-            QString end();
+            ResultItem<QString> end;
 
         protected:
             QString apiPath();

--- a/jobs/simplejob.cpp
+++ b/jobs/simplejob.cpp
@@ -1,0 +1,58 @@
+#include "simplejob.h"
+
+#include <QtCore/QJsonObject>
+#include <QtCore/QJsonValue>
+
+using namespace QMatrixClient;
+
+SimpleJob::SimpleJob(ConnectionData* conndata, JobHttpType jobType, QString name, bool needsToken)
+    : BaseJob(conndata, jobType, name, needsToken)
+{ }
+
+QVariant SimpleJob::resultItem(QString jsonKey) const
+{
+    return resultItems[jsonKey];
+}
+
+void SimpleJob::parseJson(const QJsonDocument& data)
+{
+    // If fillResult() fails it will invoke fail() from inside; but if it
+    // succeeds it will just return true, leaving room for additional
+    // processing in parseJson() overrides. Alternatively, SimpleJson::parseJson()
+    // can be called the last thing from an override, or not called at all
+    // (but then think again if you should derive from SimpleJob).
+    if (fillResult(data))
+       emitResult();
+}
+
+bool SimpleJob::fillResult(const QJsonDocument& data)
+{
+    QJsonObject json = data.object();
+    QStringList failed;
+    for (auto pItem = resultItems.begin(); pItem != resultItems.end(); ++pItem)
+    {
+        QJsonValue jsonVal = json[pItem.key()];
+        if (jsonVal.type() == QJsonValue::Undefined)
+        {
+            qDebug() << "Couldn't find JSON value for key" << pItem.key();
+            failed.push_back(pItem.key());
+            continue;
+        }
+        // We need a temporary here because QVariant::convert()
+        // is very intrusive: if it fails, it resets the QVariant
+        // type - and we need to preserve the QVariant type inside
+        // the result hashmap.
+        QVariant v = jsonVal.toVariant();
+        if (v.convert(pItem->type()))
+            *pItem = v;
+        else
+        {
+            qDebug() << "Couldn't convert" << jsonVal << "to" << pItem->type();
+            failed.push_back(pItem.key());
+        }
+    }
+    if (!failed.empty())
+        fail(UserDefinedError, "Failed to load keys: " + failed.join(", "));
+
+    return failed.empty();
+}

--- a/jobs/simplejob.h
+++ b/jobs/simplejob.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <QtCore/QVariantHash>
+
+#include "basejob.h"
+
+namespace QMatrixClient
+{
+    class SimpleJob : public BaseJob
+    {
+        public:
+            /**
+             * This template allows to add and access result items of jobs
+             * in a type-safe way. When you derive from SimpleJob, specify
+             * a member that you expect to be filled from the response JSON
+             * as ResultItem<Type> field instead of "Type field;". Then in the
+             * constructor of the derived class, initialize each result item
+             * with the response's JSON key you need to fetch this item from
+             * and the job that will parse the response (usually the second
+             * parameter will be *this).
+             * Only top-level JSON keys and primitive (non-object) types are
+             * supported so far; support of inner keys and Event* lists is in plans.
+             * Accessing the fetched item is as simple as accessing the respective
+             * field as if it were a read accessor call with the same name.
+             * get() method does the same, for cases when operator()()
+             * cannot/may not be used.
+             * Changes of result items through ResultItem<> are not allowed
+             * and won't be - it's supposed to be a read-only interface.
+             */
+            template <typename T>
+            class ResultItem
+            {
+                public:
+                    explicit ResultItem(QString k, SimpleJob& j)
+                        : jsonKey(k), job(j)
+                    {
+                        job.resultItems.insert(jsonKey, T());
+                    }
+
+                    const T get() const
+                    {
+                        return job.resultItem(jsonKey).value<T>();
+                    }
+                    const T operator()() const { return get(); }
+
+                private:
+                    SimpleJob& job;
+                    QString jsonKey;
+            };
+
+            SimpleJob(class ConnectionData* conndata, JobHttpType jobType,
+                      QString name = QString(), bool needsToken = true);
+            virtual ~SimpleJob() = default;
+
+            QVariant resultItem(QString jsonKey) const;
+        protected:
+            virtual void parseJson(const QJsonDocument &data) override;
+
+            /**
+             * Fills the hashmap of result items from the passed QJsonDocument.
+             * The list of result items should be filled before calling this
+             * function with pairs of JSON keys and empty QVariants initialized
+             * with an expected type or UnknownType if any type is acceptable.
+             *
+             * @see SimpleJob::ResultItem
+             */
+            bool fillResult(const QJsonDocument& data);
+        private:
+            // JSON key mapped to the value (already with the right type
+            // inside the QVariant)
+            QVariantHash resultItems;
+
+            template <typename ResultItemT>
+            friend class ResultItem;
+    };
+}

--- a/jobs/syncjob.cpp
+++ b/jobs/syncjob.cpp
@@ -24,8 +24,6 @@
 #include <QtCore/QJsonArray>
 #include <QtCore/QDebug>
 
-#include <QtNetwork/QNetworkReply>
-
 #include "../room.h"
 #include "../connectiondata.h"
 #include "../events/event.h"
@@ -43,8 +41,6 @@ class SyncJob::Private
         QString nextBatch;
 
         QList<SyncRoomData> roomData;
-
-        void parseEvents(QString roomId, const QJsonObject& room, JoinState joinState);
 };
 
 SyncJob::SyncJob(ConnectionData* connection, QString since)
@@ -120,42 +116,42 @@ void SyncJob::parseJson(const QJsonDocument& data)
     // TODO: account_data
     QJsonObject rooms = json.value("rooms").toObject();
 
-    QJsonObject joinRooms = rooms.value("join").toObject();
-    for( const QString& roomId: joinRooms.keys() )
+    const struct { QString jsonKey; JoinState enumVal; } roomStates[]
     {
-        d->parseEvents(roomId, joinRooms.value(roomId).toObject(), JoinState::Join);
+        { "join", JoinState::Join },
+        { "invite", JoinState::Invite },
+        { "leave", JoinState::Leave }
+    };
+    for (auto roomState: roomStates)
+    {
+        const QJsonObject rs = rooms.value(roomState.jsonKey).toObject();
+        for( auto r = rs.begin(); r != rs.end(); ++r )
+        {
+            d->roomData.append({r.key(), r.value().toObject(), roomState.enumVal});
+        }
     }
 
-    QJsonObject inviteRooms = rooms.value("invite").toObject();
-    for( const QString& roomId: inviteRooms.keys() )
-    {
-        d->parseEvents(roomId, inviteRooms.value(roomId).toObject(), JoinState::Invite);
-    }
-
-    QJsonObject leaveRooms = rooms.value("leave").toObject();
-    for( const QString& roomId: leaveRooms.keys() )
-    {
-        d->parseEvents(roomId, leaveRooms.value(roomId).toObject(), JoinState::Leave);
-    }
     emitResult();
 }
 
 SyncRoomData::SyncRoomData(QString roomId_, const QJsonObject& room_, JoinState joinState_)
     : roomId(roomId_), joinState(joinState_)
 {
-    const QList<QPair<QString, QList<Event *> *> > eventLists = {
+    const struct { QString jsonKey; QList<Event *> *evList; } eventLists[]
+    {
         { "state", &state },
         { "timeline", &timeline },
         { "ephemeral", &ephemeral },
         { "account_data", &accountData }
     };
 
-    for (auto elist: eventLists) {
-        QJsonArray array = room_.value(elist.first).toObject().value("events").toArray();
+    for (auto e: eventLists)
+    {
+        QJsonArray array = room_.value(e.jsonKey).toObject().value("events").toArray();
         for( QJsonValue val: array )
         {
             if ( Event* event = Event::fromJson(val.toObject()) )
-                elist.second->append(event);
+                e.evList->append(event);
         }
     }
 
@@ -163,14 +159,8 @@ SyncRoomData::SyncRoomData(QString roomId_, const QJsonObject& room_, JoinState 
     timelineLimited = timeline.value("limited").toBool();
     timelinePrevBatch = timeline.value("prev_batch").toString();
 
-   QJsonObject unread = room_.value("unread_notifications").toObject();
-   highlightCount = unread.value("highlight_count").toInt();
-   notificationCount = unread.value("notification_count").toInt();
-   qDebug() << "Highlights: " << highlightCount << " Notifications:" << notificationCount;
+    QJsonObject unread = room_.value("unread_notifications").toObject();
+    highlightCount = unread.value("highlight_count").toInt();
+    notificationCount = unread.value("notification_count").toInt();
+    qDebug() << "Highlights: " << highlightCount << " Notifications:" << notificationCount;
 }
-
-void SyncJob::Private::parseEvents(QString roomId, const QJsonObject& room, JoinState joinState)
-{
-    roomData.append(SyncRoomData{roomId, room, joinState});
-}
-

--- a/jobs/syncjob.cpp
+++ b/jobs/syncjob.cpp
@@ -48,7 +48,7 @@ class SyncJob::Private
 };
 
 SyncJob::SyncJob(ConnectionData* connection, QString since)
-    : BaseJob(connection, JobHttpType::GetJob)
+    : BaseJob(connection, JobHttpType::GetJob, "SyncJob")
     , d(new Private)
 {
     d->since = since;


### PR DESCRIPTION
So, here it comes - a class that can facilitate creating new jobs. It's not that you can write SimpleJob<some configuration>(some,construction,configuration) and magically get support of one more action - but I suppose it wouldn't be quite readable anyway. Kindly consider, along with a usual dose of code cleanup (actually, all the interesting stuff is in the last commit).