### PR TITLE
Load a different set of event lists depending on the join state (and actually introduce EventList class)

### DIFF
--- a/jobs/syncjob.cpp
+++ b/jobs/syncjob.cpp
@@ -24,8 +24,6 @@
 #include <QtCore/QJsonArray>
 #include <QtCore/QDebug>
 
-#include <QtNetwork/QNetworkReply>
-
 #include "../room.h"
 #include "../connectiondata.h"
 #include "../events/event.h"
@@ -43,8 +41,6 @@ class SyncJob::Private
         QString nextBatch;
 
         QList<SyncRoomData> roomData;
-
-        void parseEvents(QString roomId, const QJsonObject& room, JoinState joinState);
 };
 
 SyncJob::SyncJob(ConnectionData* connection, QString since)
@@ -120,57 +116,64 @@ void SyncJob::parseJson(const QJsonDocument& data)
     // TODO: account_data
     QJsonObject rooms = json.value("rooms").toObject();
 
-    QJsonObject joinRooms = rooms.value("join").toObject();
-    for( const QString& roomId: joinRooms.keys() )
+    const struct { QString jsonKey; JoinState enumVal; } roomStates[]
     {
-        d->parseEvents(roomId, joinRooms.value(roomId).toObject(), JoinState::Join);
+        { "join", JoinState::Join },
+        { "invite", JoinState::Invite },
+        { "leave", JoinState::Leave }
+    };
+    for (auto roomState: roomStates)
+    {
+        const QJsonObject rs = rooms.value(roomState.jsonKey).toObject();
+        d->roomData.reserve(rs.size());
+        for( auto r = rs.begin(); r != rs.end(); ++r )
+        {
+            d->roomData.push_back({r.key(), r.value().toObject(), roomState.enumVal});
+        }
     }
 
-    QJsonObject inviteRooms = rooms.value("invite").toObject();
-    for( const QString& roomId: inviteRooms.keys() )
-    {
-        d->parseEvents(roomId, inviteRooms.value(roomId).toObject(), JoinState::Invite);
-    }
-
-    QJsonObject leaveRooms = rooms.value("leave").toObject();
-    for( const QString& roomId: leaveRooms.keys() )
-    {
-        d->parseEvents(roomId, leaveRooms.value(roomId).toObject(), JoinState::Leave);
-    }
     emitResult();
 }
 
-SyncRoomData::SyncRoomData(QString roomId_, const QJsonObject& room_, JoinState joinState_)
-    : roomId(roomId_), joinState(joinState_)
+void SyncRoomData::EventList::fromJson(const QJsonObject& roomContents)
 {
-    const QList<QPair<QString, QList<Event *> *> > eventLists = {
-        { "state", &state },
-        { "timeline", &timeline },
-        { "ephemeral", &ephemeral },
-        { "account_data", &accountData }
-    };
+    auto l = eventListFromJson(roomContents[jsonKey].toObject()["events"].toArray());
+    swap(l);
+}
 
-    for (auto elist: eventLists) {
-        QJsonArray array = room_.value(elist.first).toObject().value("events").toArray();
-        for( QJsonValue val: array )
-        {
-            if ( Event* event = Event::fromJson(val.toObject()) )
-                elist.second->append(event);
-        }
+SyncRoomData::SyncRoomData(QString roomId_, const QJsonObject& room_, JoinState joinState_)
+    : roomId(roomId_)
+    , joinState(joinState_)
+    , state("state")
+    , timeline("timeline")
+    , ephemeral("ephemeral")
+    , accountData("account_data")
+    , inviteState("invite_state")
+{
+    switch (joinState) {
+        case JoinState::Invite:
+            inviteState.fromJson(room_);
+            break;
+        case JoinState::Join:
+            state.fromJson(room_);
+            timeline.fromJson(room_);
+            ephemeral.fromJson(room_);
+            accountData.fromJson(room_);
+            break;
+        case JoinState::Leave:
+            state.fromJson(room_);
+            timeline.fromJson(room_);
+            break;
+    default:
+        qWarning() << "SyncRoomData: Unknown JoinState value, ignoring:" << int(joinState);
     }
 
     QJsonObject timeline = room_.value("timeline").toObject();
     timelineLimited = timeline.value("limited").toBool();
     timelinePrevBatch = timeline.value("prev_batch").toString();
 
-   QJsonObject unread = room_.value("unread_notifications").toObject();
-   highlightCount = unread.value("highlight_count").toInt();
-   notificationCount = unread.value("notification_count").toInt();
-   qDebug() << "Highlights: " << highlightCount << " Notifications:" << notificationCount;
+    QJsonObject unread = room_.value("unread_notifications").toObject();
+    highlightCount = unread.value("highlight_count").toInt();
+    notificationCount = unread.value("notification_count").toInt();
+    qDebug() << "Highlights: " << highlightCount << " Notifications:" << notificationCount;
 }
-
-void SyncJob::Private::parseEvents(QString roomId, const QJsonObject& room, JoinState joinState)
-{
-    roomData.append(SyncRoomData{roomId, room, joinState});
-}
-

--- a/jobs/syncjob.h
+++ b/jobs/syncjob.h
@@ -30,12 +30,22 @@ namespace QMatrixClient
     class SyncRoomData
     {
     public:
+        class EventList : public QList<Event*>
+        {
+            private:
+                QString jsonKey;
+            public:
+                explicit EventList(QString k) : jsonKey(k) { }
+                void fromJson(const QJsonObject& roomContents);
+        };
+
         QString roomId;
         JoinState joinState;
-        QList<Event*> state;
-        QList<Event*> timeline;
-        QList<Event*> ephemeral;
-        QList<Event*> accountData;
+        EventList state;
+        EventList timeline;
+        EventList ephemeral;
+        EventList accountData;
+        EventList inviteState;
 
         bool timelineLimited;
         QString timelinePrevBatch;


### PR DESCRIPTION
This commit is an inadvertent test for (non-)triviality :) Basically, it doesn't change functionality though it tightens up the code to more accurately follow the JSON structure described in the spec. At the same time, there's a bit of refactoring that spills over to SyncRoomData public interface (though, again, it's perfectly compatible with the rest of the code). Given that SyncRoomData itself is not used by the clients AFAIK, I think it's ok to self-approve it.