### PR TITLE
Require Qt 5.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@ set(CMAKE_AUTOMOC ON)
 set( BUNDLE_KCOREADDONS "AUTO" CACHE STRING "Build own KCoreAddons, one of ON, OFF and AUTO" )
 set( KCOREADDONS_DIR "kcoreaddons" CACHE STRING "Local path to bundled KCoreAddons sources, if own KCoreAddons is built" )
 
-find_package(Qt5Core 5.3.0) # For JSON (de)serialization
-find_package(Qt5Network 5.3.0) # For networking
-find_package(Qt5Gui 5.3.0) # For userpics
+find_package(Qt5Core 5.2.0) # For JSON (de)serialization
+find_package(Qt5Network 5.2.0) # For networking
+find_package(Qt5Gui 5.2.0) # For userpics
 
 if ( (NOT BUNDLE_KCOREADDONS STREQUAL "ON")
      AND (NOT BUNDLE_KCOREADDONS STREQUAL "OFF")

--- a/jobs/passwordlogin.cpp
+++ b/jobs/passwordlogin.cpp
@@ -74,7 +74,7 @@ QString PasswordLogin::apiPath()
 QJsonObject PasswordLogin::data()
 {
     QJsonObject json;
-    json.insert("type", "m.login.password");
+    json.insert("type", QLatin1String("m.login.password"));
     json.insert("user", d->user);
     json.insert("password", d->password);
     return json;


### PR DESCRIPTION
I don't know why you are requiring Qt 5.3, however this simple change is enough to get libqmatrixclient running with Qt 5.2.