### PR TITLE
Server call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,9 +67,11 @@ set(libqmatrixclient_SRCS
    events/typingevent.cpp
    events/receiptevent.cpp
    events/unknownevent.cpp
+   serverapi/servercallsetup.cpp
+   serverapi/servercall.cpp
+   serverapi/passwordlogin.cpp
    jobs/basejob.cpp
    jobs/checkauthmethods.cpp
-   jobs/passwordlogin.cpp
    jobs/postmessagejob.cpp
    jobs/postreceiptjob.cpp
    jobs/joinroomjob.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(libqmatrixclient_SRCS
    serverapi/servercallsetup.cpp
    serverapi/servercall.cpp
    serverapi/passwordlogin.cpp
+   serverapi/getmediathumbnail.cpp
    jobs/basejob.cpp
    jobs/checkauthmethods.cpp
    jobs/postmessagejob.cpp

--- a/connection.cpp
+++ b/connection.cpp
@@ -86,7 +86,7 @@ void Connection::connectWithToken(QString userId, QString token)
 
 void Connection::reconnect()
 {
-    auto loginJob = callServer(PasswordLogin(d->username, d->password), true);
+    auto loginJob = callServer(PasswordLogin(d->username, d->password));
     connect( loginJob, &ServerCallBase::success, [=]() {
         d->userId = loginJob->results().id;
         emit reconnected();

--- a/connection.cpp
+++ b/connection.cpp
@@ -22,7 +22,7 @@
 #include "user.h"
 #include "events/event.h"
 #include "room.h"
-#include "jobs/passwordlogin.h"
+#include "serverapi/passwordlogin.h"
 #include "jobs/logoutjob.h"
 #include "jobs/geteventsjob.h"
 #include "jobs/postmessagejob.h"
@@ -62,15 +62,14 @@ void Connection::resolveServer(QString domain)
 
 void Connection::connectToServer(QString user, QString password)
 {
-    PasswordLogin* loginJob = new PasswordLogin(d->data, user, password);
-    connect( loginJob, &PasswordLogin::success, [=] () {
-        qDebug() << "Our user ID: " << loginJob->id();
-        connectWithToken(loginJob->id(), loginJob->token());
+    auto loginJob = callServer(PasswordLogin(user, password));
+    loginJob->onSuccess([=] (const PasswordLogin& result) {
+        qDebug() << "Our user ID: " << result.id;
+        connectWithToken(result.id, result.token);
     });
-    connect( loginJob, &PasswordLogin::failure, [=] () {
-        emit loginError(loginJob->errorString());
+    loginJob->onFailure([=] (const PasswordLogin& result) {
+        emit loginError(result.status().message);
     });
-    loginJob->start();
     d->username = user; // to be able to reconnect
     d->password = password;
 }
@@ -87,16 +86,15 @@ void Connection::connectWithToken(QString userId, QString token)
 
 void Connection::reconnect()
 {
-    PasswordLogin* loginJob = new PasswordLogin(d->data, d->username, d->password );
-    connect( loginJob, &PasswordLogin::success, [=] () {
-        d->userId = loginJob->id();
+    auto loginJob = callServer(PasswordLogin(d->username, d->password), true);
+    connect( loginJob, &ServerCallBase::success, [=]() {
+        d->userId = loginJob->results().id;
         emit reconnected();
     });
-    connect( loginJob, &PasswordLogin::failure, [=] () {
-        emit loginError(loginJob->errorString());
+    connect( loginJob, &ServerCallBase::failure, [=]() {
+        emit loginError(loginJob->status().message);
         d->isConnected = false;
     });
-    loginJob->start();
 }
 
 void Connection::logout()

--- a/connection.h
+++ b/connection.h
@@ -19,7 +19,11 @@
 #ifndef QMATRIXCLIENT_CONNECTION_H
 #define QMATRIXCLIENT_CONNECTION_H
 
+#include "serverapi/servercall.h"
+
 #include <QtCore/QObject>
+
+#include <utility>
 
 namespace QMatrixClient
 {
@@ -63,6 +67,13 @@ namespace QMatrixClient
             Q_INVOKABLE virtual User* user();
             Q_INVOKABLE virtual QString userId();
             Q_INVOKABLE virtual QString token();
+
+            template <typename SetupT>
+            ServerCall<SetupT>* callServer(SetupT&& setup, bool startNow = true)
+            {
+                return new ServerCall<SetupT>
+                        (connectionData(), std::forward<SetupT>(setup), startNow);
+            }
 
         signals:
             void resolved();

--- a/serverapi/getmediathumbnail.cpp
+++ b/serverapi/getmediathumbnail.cpp
@@ -1,0 +1,43 @@
+/******************************************************************************
+ * Copyright (C) 2016 Felix Rohrbach <kde@fxrh.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "getmediathumbnail.h"
+
+#include <QtCore/QDebug>
+
+using namespace QMatrixClient;
+
+GetMediaThumbnail::GetMediaThumbnail(QUrl url, int requestedWidth, int requestedHeight,
+                                     ThumbnailType thumbnailType)
+    : ServerCallSetup("MediaThumbnailJob",
+        RequestParams(HttpType::Get
+        , QString("/_matrix/media/v1/thumbnail/%1%2").arg(url.host()).arg(url.path())
+        , Query(
+            { { "width", QString::number(requestedWidth) }
+            , { "height", QString::number(requestedHeight) }
+            , { "method", thumbnailType == ThumbnailType::Scale ? "scale" : "crop" }
+            })
+        ))
+{ }
+
+void GetMediaThumbnail::fillResult(QByteArray bytes)
+{
+    if (!thumbnail.loadFromData(bytes))
+        setStatus(CallStatus::UserDefinedError,
+                  "MediaThumbnailJob: could not read image data");
+}

--- a/serverapi/getmediathumbnail.h
+++ b/serverapi/getmediathumbnail.h
@@ -26,7 +26,7 @@ namespace QMatrixClient
 {
     enum class ThumbnailType {Crop, Scale};
 
-    class GetMediaThumbnail: public ServerCallSetup<NoResultAdaptor>
+    class GetMediaThumbnail: public ServerCallSetup<GetBytes>
     {
         public:
             GetMediaThumbnail(QUrl url, int requestedWidth, int requestedHeight,

--- a/serverapi/getmediathumbnail.h
+++ b/serverapi/getmediathumbnail.h
@@ -1,0 +1,39 @@
+/******************************************************************************
+ * Copyright (C) 2016 Felix Rohrbach <kde@fxrh.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#pragma once
+
+#include "servercallsetup.h"
+
+#include <QtGui/QPixmap>
+
+namespace QMatrixClient
+{
+    enum class ThumbnailType {Crop, Scale};
+
+    class GetMediaThumbnail: public ServerCallSetup<NoResultAdaptor>
+    {
+        public:
+            GetMediaThumbnail(QUrl url, int requestedWidth, int requestedHeight,
+                              ThumbnailType thumbnailType=ThumbnailType::Scale);
+
+            QPixmap thumbnail;
+
+            void fillResult(QByteArray bytes);
+    };
+}

--- a/serverapi/passwordlogin.cpp
+++ b/serverapi/passwordlogin.cpp
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright (C) 2016 Kitsune Ral <kitsune-ral@users.sf.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "passwordlogin.h"
+
+using namespace QMatrixClient;
+
+PasswordLogin::PasswordLogin(QString user, QString password)
+    : ServerCallSetup("PasswordLogin",
+        RequestParams (HttpType::Post, "_matrix/client/r0/login"
+        , Query()
+        , Data(
+            { { "type", "m.login.password" }
+            , { "user", user }
+            , { "password", password }
+            })
+        , false
+        ))
+{ }
+
+
+void PasswordLogin::fillResult(const QJsonObject& json)
+{
+    if( !json.contains("access_token") || !json.contains("home_server") || !json.contains("user_id") )
+    {
+        setStatus(CallStatus::UserDefinedError, "Unexpected data");
+    }
+    token = json.value("access_token").toString();
+    server = json.value("home_server").toString();
+    id = json.value("user_id").toString();
+}

--- a/serverapi/passwordlogin.h
+++ b/serverapi/passwordlogin.h
@@ -1,0 +1,39 @@
+/******************************************************************************
+ * Copyright (C) 2016 Kitsune Ral <kitsune-ral@users.sf.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef QMATRIXCLIENT_PASSWORDLOGIN_H
+#define QMATRIXCLIENT_PASSWORDLOGIN_H
+
+#include "servercallsetup.h"
+
+namespace QMatrixClient
+{
+    class PasswordLogin : public ServerCallSetup<>
+    {
+        public:
+            PasswordLogin(QString user, QString password);
+
+            QString token;
+            QString id;
+            QString server;
+
+            void fillResult(const QJsonObject& json);
+    };
+}
+
+#endif // QMATRIXCLIENT_PASSWORDLOGIN_H

--- a/serverapi/requestparams.h
+++ b/serverapi/requestparams.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <QtCore/QString>
+#include <QtCore/QUrlQuery>
+#include <QtCore/QJsonObject>
+#include <QtCore/QJsonDocument>
+
+namespace QMatrixClient
+{
+    /**
+     * This class defines the generic set of parameters for a request to
+     * a Matrix server. It also provides a set of wrapper classes that ease
+     * creation of input from a list of key-value pairs. Thanks to an
+     * implicit QList<> constructor, such list can be passed as a braced-init
+     * list.
+     */
+    class RequestParams
+    {
+        public: // Supplementary type definitions
+            class Query : public QUrlQuery
+            {
+                public:
+                    using QUrlQuery::QUrlQuery;
+                    Query() = default;
+                    Query(QList<QPair<QString, QString> > l)
+                    {
+                        setQueryItems(l);
+                    }
+            };
+            class Data : public QJsonObject
+            {
+                public:
+                    using QJsonObject::QJsonObject;
+                    Data() = default;
+                    Data(QList<QPair<QString, QString> > l)
+                    {
+                        for (auto i: l)
+                            insert(i.first, i.second);
+                    }
+            };
+            enum class HttpType { Get, Put, Post };
+
+        public: // Methods
+            RequestParams(HttpType t, QString p,
+                    Query q = Query(), Data d = Data(), bool needsToken = true)
+                : m_type(t), m_endpoint(p), m_query(q), m_data(d)
+                , m_needsToken(needsToken)
+            { }
+
+            HttpType type() const { return m_type; }
+            QString apiPath() const { return m_endpoint; }
+            QUrlQuery query() const { return m_query; }
+            QByteArray data() const { return QJsonDocument(m_data).toJson(); }
+            bool needsToken() const { return m_needsToken; }
+
+        private:
+            HttpType m_type;
+            QString m_endpoint;
+            Query m_query;
+            Data m_data;
+            bool m_needsToken;
+    };
+
+}

--- a/serverapi/servercall.cpp
+++ b/serverapi/servercall.cpp
@@ -1,0 +1,202 @@
+/******************************************************************************
+ * Copyright (C) 2016 Kitsune Ral <kitsune-ral@users.sf.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "servercall.h"
+
+#include "connectiondata.h"
+#include "servercallsetup.h"
+
+#include <QtNetwork/QNetworkRequest>
+#include <QtCore/QUrlQuery>
+#include <QtCore/QTimer>
+
+using namespace QMatrixClient;
+
+struct NetworkReplyDeleter : public QScopedPointerDeleteLater
+{
+    static inline void cleanup(QNetworkReply* reply)
+    {
+        if (reply && reply->isRunning())
+            reply->abort();
+        QScopedPointerDeleteLater::cleanup(reply);
+    }
+};
+
+class ServerCallBase::Private
+{
+    public:
+        Private(ConnectionData* c, QString n)
+            : connection(c), name(n), reply(nullptr), pStatus(nullptr)
+        {}
+
+        inline void sendRequest(const RequestParams& params);
+
+        ConnectionData* connection;
+        QString name;
+
+        QScopedPointer<QNetworkReply, NetworkReplyDeleter> reply;
+        QByteArray rawData;
+
+        // The actual status object is managed in ServerCall<>
+        CallStatus* pStatus;
+};
+
+void ServerCallBase::Private::sendRequest(const RequestParams& params)
+{
+    QUrl url = connection->baseUrl();
+    url.setPath( url.path() + "/" + params.apiPath() );
+    QUrlQuery query = params.query();
+    if( params.needsToken() )
+        query.addQueryItem("access_token", connection->token());
+    url.setQuery(query);
+    QNetworkRequest req = QNetworkRequest(url);
+    req.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+    req.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
+    req.setMaximumRedirectsAllowed(10);
+#endif
+    switch( params.type() )
+    {
+        case RequestParams::HttpType::Get:
+            reply.reset( connection->nam()->get(req) );
+            break;
+        case RequestParams::HttpType::Post:
+            reply.reset( connection->nam()->post(req, params.data()) );
+            break;
+        case RequestParams::HttpType::Put:
+            reply.reset( connection->nam()->put(req, params.data()) );
+            break;
+    }
+}
+
+ServerCallBase::ServerCallBase(ConnectionData* data, QString name)
+    : d(new Private(data, name))
+{
+    setObjectName(name);
+}
+
+void ServerCallBase::init(ServerCallSetupBase& setup)
+{
+    d->pStatus = setup.statusPtr();
+}
+
+ServerCallBase::~ServerCallBase()
+{ }
+
+void ServerCallBase::doStart(const RequestParams& params)
+{
+    setStatus(CallStatus::PendingResult);
+
+    d->sendRequest(params);
+    connect( reply(), &QNetworkReply::sslErrors, this, &ServerCallBase::sslErrors );
+    QTimer::singleShot( 120*1000, this, SLOT(timeout()) );
+}
+
+void ServerCallBase::abandon()
+{
+    finish(false);
+}
+
+bool ServerCallBase::pendingReply() const
+{
+    return d->reply && d->reply->isRunning();
+}
+
+CallStatus ServerCallBase::status() const
+{
+    // Will crash if you try to use it with no pStatus pointer set. Use bindStatus()
+    Q_ASSERT(d->pStatus);
+    return *(d->pStatus);
+}
+
+const QByteArray&ServerCallBase::rawData() const
+{
+    return d->rawData;
+}
+
+void ServerCallBase::setStatus(CallStatus cs)
+{
+    // Will crash if you try to use it with no pStatus pointer set. Use bindStatus()
+    Q_ASSERT(d->pStatus);
+    *(d->pStatus) = cs;
+    if (!cs.good())
+    {
+        qWarning() << "Server call" << objectName() << "failed:"
+                   << "CallStatus(" << cs.code << "," << cs.message << ")";
+    }
+}
+
+void ServerCallBase::setStatus(int code)
+{
+    setStatus(CallStatus(code));
+}
+
+QNetworkReply* ServerCallBase::reply() const
+{
+    return d->reply.data();
+}
+
+bool ServerCallBase::readReply()
+{
+    if( reply()->error() == QNetworkReply::NoError )
+    {
+        setStatus(CallStatus::Success);
+        d->rawData = reply()->readAll();
+    }
+    else
+    {
+        setStatus({ CallStatus::NetworkError,
+              tr("%1 %2").arg(d->reply->error()).arg(d->reply->errorString()) });
+    }
+    return status().good();
+}
+
+void ServerCallBase::finish(bool emitResult)
+{
+    if (!d->reply)
+    {
+        qWarning() << objectName()
+                   << ": empty network reply (finish() called more than once?)";
+        return;
+    }
+    if (emitResult)
+    {
+        emit resultReady();
+        if (status().good())
+            emit success();
+        else
+            emit failure();
+    }
+
+    d->reply.reset();
+    deleteLater();
+}
+
+void ServerCallBase::timeout()
+{
+    setStatus({ CallStatus::TimeoutError, "The job has timed out" });
+    abandon();
+}
+
+void ServerCallBase::sslErrors(const QList<QSslError>& errors)
+{
+    foreach (const QSslError &error, errors) {
+        qWarning() << "SSL ERROR" << error.errorString();
+    }
+    d->reply->ignoreSslErrors(); // TODO: insecure! should prompt user first
+}

--- a/serverapi/servercall.cpp
+++ b/serverapi/servercall.cpp
@@ -40,14 +40,13 @@ struct NetworkReplyDeleter : public QScopedPointerDeleteLater
 class ServerCallBase::Private
 {
     public:
-        Private(ConnectionData* c, QString n)
-            : connection(c), name(n), reply(nullptr), pStatus(nullptr)
-        {}
+        explicit Private(ConnectionData* c)
+            : connection(c), reply(nullptr), pStatus(nullptr)
+        { }
 
         inline void sendRequest(const RequestParams& params);
 
         ConnectionData* connection;
-        QString name;
 
         QScopedPointer<QNetworkReply, NetworkReplyDeleter> reply;
         QByteArray rawData;
@@ -85,7 +84,7 @@ void ServerCallBase::Private::sendRequest(const RequestParams& params)
 }
 
 ServerCallBase::ServerCallBase(ConnectionData* data, QString name)
-    : d(new Private(data, name))
+    : d(new Private(data))
 {
     setObjectName(name);
 }

--- a/serverapi/servercall.cpp
+++ b/serverapi/servercall.cpp
@@ -52,7 +52,7 @@ class ServerCallBase::Private
         QScopedPointer<QNetworkReply, NetworkReplyDeleter> reply;
         QByteArray rawData;
 
-        // The actual status object is managed in ServerCall<>
+        // The actual status object is managed in ServerCall<>::setup
         CallStatus* pStatus;
 };
 
@@ -119,7 +119,6 @@ bool ServerCallBase::pendingReply() const
 
 CallStatus ServerCallBase::status() const
 {
-    // Will crash if you try to use it with no pStatus pointer set. Use bindStatus()
     Q_ASSERT(d->pStatus);
     return *(d->pStatus);
 }
@@ -131,7 +130,6 @@ const QByteArray&ServerCallBase::rawData() const
 
 void ServerCallBase::setStatus(CallStatus cs)
 {
-    // Will crash if you try to use it with no pStatus pointer set. Use bindStatus()
     Q_ASSERT(d->pStatus);
     *(d->pStatus) = cs;
     if (!cs.good())

--- a/serverapi/servercall.h
+++ b/serverapi/servercall.h
@@ -18,28 +18,28 @@
 
 #pragma once
 
-#include <QtNetwork/QNetworkReply>
 #include <QtCore/QObject>
 #include <QtCore/QScopedPointer>
+
+class QNetworkReply;
+class QSslError;
+class QByteArray;
 
 namespace QMatrixClient
 {
     class ConnectionData;
     class CallStatus;
     class RequestParams;
-    class ServerCallSetupBase;
 
     class ServerCallBase : public QObject
     {
             Q_OBJECT
+
         protected:
-            // Construction is only allowed from ServerCall<>
-            ServerCallBase(ConnectionData* data, QString name);
-            // Two-phase init, alas...
-            void init(ServerCallSetupBase& setup);
-            // Copying not allowed
-            ServerCallBase(ServerCallBase&) = delete;
-            // Deletion will be done from within the object
+            // This class is for inheritance only (as of now, at least)
+            ServerCallBase(ConnectionData* data, QString name,
+                           const RequestParams& params);
+            // Deletion will be done from within the object; don't delete explicitly
             virtual ~ServerCallBase();
 
         public:
@@ -50,17 +50,6 @@ namespace QMatrixClient
              * deletion of the server call object.
              */
             void abandon();
-
-            /**
-             * Returns whether the server call is waiting for a server reply.
-             * Normally will return true after start() invocation and before
-             * the finished() signal is emitted and false at all other times
-             * (including slots that handle the finished() signal).
-             *
-             * @return true if the server call is waiting for a reply that hasn't
-             * arrived yet; false otherwise
-             */
-            bool pendingReply() const;
 
             /**
              * Returns the current status of the server call. Note that
@@ -97,42 +86,33 @@ namespace QMatrixClient
              * @note: The name is borrowed from QFutureWatcher that has
              * resultReadyAt() signal.
              *
-             * @param call the object that emitted this signal
-             *
              * @see success, failure, ServerCall<>::onAnyResult
              */
             void resultReady();
 
             /**
              * Emitted together with result() but only if there's no error.
-             *
-             * @param res the result of the server call
              */
             void success();
 
             /**
              * Emitted together with result() if there's an error.
              * Same as result(), this won't be emitted in case of kill().
-             *
-             * @param error the structure with the code and details of the errror
              */
             void failure();
 
         protected:
             /**
              * Sets the call to the specified status. setStatus() doesn't
-             * emit signals with the status; to do that, use finish after
+             * emit signals with the status; to do that, use finish() after
              * setting the final call status.
-             *
-             * To extend the list of error codes, define an (anonymous) enum
-             * with additional values starting at CallStatus::UserDefinedError
              *
              * @see finish, CallStatus
              */
             void setStatus(CallStatus cs);
             /**
              * Same as setStatus(CallStatus), for cases when there's only a bare
-             * code in the status.
+             * code in the status. Clears the message part of the status.
              *
              * @param code a status code, as defined in CallStatus or custom extensions
              *
@@ -142,7 +122,7 @@ namespace QMatrixClient
 
             /**
              * Provides access to a (possibly pending) network reply object.
-             * The memory allocated for this object is managed by ServerCallBase,
+             * The memory allocated for this object is managed inside ServerCallBase,
              * and shouldn't be freed externally.
              */
             QNetworkReply* reply() const;
@@ -155,20 +135,19 @@ namespace QMatrixClient
              *
              * @param emitResult if true, all necessary signals will be emitted
              * according to the current status of the server call. If false,
-             * the server-call completes and self-deletes silently.
+             * the server call completes and self-deletes silently.
              *
              * @see resultReady()
              */
             void finish(bool emitResult);
 
-        protected slots:
+        private slots:
+            void gotReply();
             void timeout();
             void sslErrors(const QList<QSslError>& errors);
 
         protected:
-            // Callbacks for ServerCall<>
-            void doStart(const RequestParams& params);
-            bool readReply();
+            virtual void makeResult(const QByteArray& bytes) = 0;
 
         private:
             class Private;
@@ -179,37 +158,22 @@ namespace QMatrixClient
     class ServerCall : public ServerCallBase
     {
         public:
-            ServerCall(ConnectionData* c, SetupT&& s, bool startNow = true)
-                : ServerCallBase(c, s.name())
+            ServerCall(ConnectionData* c, SetupT&& s)
+                : ServerCallBase(c, s.name(), s.requestParams())
                 , setup(std::forward<SetupT>(s))
-            {
-                init(setup);
-                if (startNow)
-                    start();
-            }
-
-            /**
-             * Sends the request on the network and subscribes to a reply
-             * from the Matrix server.
-             */
-            void start()
-            {
-                doStart(setup.requestParams());
-                connect( reply(), &QNetworkReply::finished,
-                         this, &ServerCall::gotReply );
-            }
+            { }
 
             /**
              * After the server call completes, calling this will get
              * a reference to the object with server call results. Use it
              * if you have only a pointer to the ServerCall<> object at hand.
-             * Alternatively, use callback adaptors (whenReady, onSuccess,
+             * Alternatively, use callback adaptors (onAnyResult, onSuccess,
              * onFailure) to subscribe to resultReady(), success() and failure()
              * signals respectively; the callback adaptors will do the work
              * of storing the ServerCall<> pointer and supplying your handler
              * with the actual results object.
              *
-             * @see whenReady, onSuccess, onFailure
+             * @see onAnyResult, onSuccess, onFailure
              */
             const SetupT& results() const { return setup; }
 
@@ -258,17 +222,15 @@ namespace QMatrixClient
                         [=]() { handler(results()); });
             }
 
-        private:
-            void gotReply()
+        protected:
+            virtual void makeResult(const QByteArray& bytes) override
             {
-                if (readReply())
-                {
-                    const auto data = setup.preprocess(rawData());
-                    if (status().good())
-                        setup.fillResult(data);
-                }
-
-                finish(true);
+                const typename SetupT::preprocessed_type data = setup.preprocess(bytes);
+                if (setup.status().good())
+                    setup.fillResult(data);
+                // Update ServerCallBase status from the setup status;
+                // clients can use either status to their choice
+                setStatus(setup.status());
             }
 
         private:

--- a/serverapi/servercall.h
+++ b/serverapi/servercall.h
@@ -1,0 +1,277 @@
+/******************************************************************************
+ * Copyright (C) 2016 Kitsune Ral <kitsune-ral@users.sf.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#pragma once
+
+#include <QtNetwork/QNetworkReply>
+#include <QtCore/QObject>
+#include <QtCore/QScopedPointer>
+
+namespace QMatrixClient
+{
+    class ConnectionData;
+    class CallStatus;
+    class RequestParams;
+    class ServerCallSetupBase;
+
+    class ServerCallBase : public QObject
+    {
+            Q_OBJECT
+        protected:
+            // Construction is only allowed from ServerCall<>
+            ServerCallBase(ConnectionData* data, QString name);
+            // Two-phase init, alas...
+            void init(ServerCallSetupBase& setup);
+            // Copying not allowed
+            ServerCallBase(ServerCallBase&) = delete;
+            // Deletion will be done from within the object
+            virtual ~ServerCallBase();
+
+        public:
+            /**
+             * Abandons the server call.
+             *
+             * This stops waiting for a reply from the server and arranges
+             * deletion of the server call object.
+             */
+            void abandon();
+
+            /**
+             * Returns whether the server call is waiting for a server reply.
+             * Normally will return true after start() invocation and before
+             * the finished() signal is emitted and false at all other times
+             * (including slots that handle the finished() signal).
+             *
+             * @return true if the server call is waiting for a reply that hasn't
+             * arrived yet; false otherwise
+             */
+            bool pendingReply() const;
+
+            /**
+             * Returns the current status of the server call. Note that
+             * the status before the reply has arrived is PendingResult, not
+             * NoError - use CallStatus::good() on the returned structure
+             * to check whether the server call is in a good shape.
+             *
+             * @return the current status of the server call.
+             */
+            CallStatus status() const;
+
+            /**
+             * Provides access to the data from the server in their original
+             * form, as arrived from the network.
+             *
+             */
+            const QByteArray& rawData() const;
+
+        signals:
+            /**
+             * Emitted when a call has finished, succesfully or unsuccesfully
+             * (except when killed). Use status() to know if the call finished
+             * with error. Alternatively, connect to success() and/or failure()
+             * signals that only get emitted for successful or failed calls,
+             * respectively.
+             * There's no guarantee to emit resultReady() in a particular order
+             * with success() and failure(); the current implementation emits
+             * resultReady() first but this can change at any time. Connecting
+             * to resultReady() and any of success() or failure() at the same time
+             * is generally a bad idea; in such cases connecting to resultReady()
+             * and using a check like 'if (status().good())' in the handler
+             * should be sufficient to do everything.
+             *
+             * @note: The name is borrowed from QFutureWatcher that has
+             * resultReadyAt() signal.
+             *
+             * @param call the object that emitted this signal
+             *
+             * @see success, failure, ServerCall<>::onAnyResult
+             */
+            void resultReady();
+
+            /**
+             * Emitted together with result() but only if there's no error.
+             *
+             * @param res the result of the server call
+             */
+            void success();
+
+            /**
+             * Emitted together with result() if there's an error.
+             * Same as result(), this won't be emitted in case of kill().
+             *
+             * @param error the structure with the code and details of the errror
+             */
+            void failure();
+
+        protected:
+            /**
+             * Sets the call to the specified status. setStatus() doesn't
+             * emit signals with the status; to do that, use finish after
+             * setting the final call status.
+             *
+             * To extend the list of error codes, define an (anonymous) enum
+             * with additional values starting at CallStatus::UserDefinedError
+             *
+             * @see finish, CallStatus
+             */
+            void setStatus(CallStatus cs);
+            /**
+             * Same as setStatus(CallStatus), for cases when there's only a bare
+             * code in the status.
+             *
+             * @param code a status code, as defined in CallStatus or custom extensions
+             *
+             * @see CallStatus
+             */
+            void setStatus(int code);
+
+            /**
+             * Provides access to a (possibly pending) network reply object.
+             * The memory allocated for this object is managed by ServerCallBase,
+             * and shouldn't be freed externally.
+             */
+            QNetworkReply* reply() const;
+
+            /**
+             * Utility function to emit (if requested) signals depending on
+             * the reply state and self-delete the server call object.
+             *
+             * @note: Deletes the object using deleteLater()
+             *
+             * @param emitResult if true, all necessary signals will be emitted
+             * according to the current status of the server call. If false,
+             * the server-call completes and self-deletes silently.
+             *
+             * @see resultReady()
+             */
+            void finish(bool emitResult);
+
+        protected slots:
+            void timeout();
+            void sslErrors(const QList<QSslError>& errors);
+
+        protected:
+            // Callbacks for ServerCall<>
+            void doStart(const RequestParams& params);
+            bool readReply();
+
+        private:
+            class Private;
+            QScopedPointer<Private> d;
+    };
+
+    template <class SetupT>
+    class ServerCall : public ServerCallBase
+    {
+        public:
+            ServerCall(ConnectionData* c, SetupT&& s, bool startNow = true)
+                : ServerCallBase(c, s.name())
+                , setup(std::forward<SetupT>(s))
+            {
+                init(setup);
+                if (startNow)
+                    start();
+            }
+
+            /**
+             * Sends the request on the network and subscribes to a reply
+             * from the Matrix server.
+             */
+            void start()
+            {
+                doStart(setup.requestParams());
+                connect( reply(), &QNetworkReply::finished,
+                         this, &ServerCall::gotReply );
+            }
+
+            /**
+             * After the server call completes, calling this will get
+             * a reference to the object with server call results. Use it
+             * if you have only a pointer to the ServerCall<> object at hand.
+             * Alternatively, use callback adaptors (whenReady, onSuccess,
+             * onFailure) to subscribe to resultReady(), success() and failure()
+             * signals respectively; the callback adaptors will do the work
+             * of storing the ServerCall<> pointer and supplying your handler
+             * with the actual results object.
+             *
+             * @see whenReady, onSuccess, onFailure
+             */
+            const SetupT& results() const { return setup; }
+
+            /**
+             * Connects the supplied handler to the resultReady() signal.
+             *
+             * @param handler a function or a function object that accepts
+             * a single parameter of type SetupT.
+             *
+             * @see ServerCallBase::resultReady
+             */
+            template <typename HandlerT>
+            void onAnyResult(HandlerT handler)
+            {
+                connect(this, &ServerCallBase::resultReady,
+                        [=]() { handler(results()); });
+            }
+
+            /**
+             * Connects the supplied handler to the success() signal.
+             *
+             * @param handler a function or a function object that accepts
+             * a single parameter of type SetupT.
+             *
+             * @see ServerCallBase::success
+             */
+            template <typename HandlerT>
+            void onSuccess(HandlerT handler) const
+            {
+                connect(this, &ServerCallBase::success,
+                        [=]() { handler(results()); });
+            }
+
+            /**
+             * Connects the supplied handler to the failure() signal.
+             *
+             * @param handler a function or a function object that accepts
+             * a single parameter of type SetupT.
+             *
+             * @see ServerCallBase::failure
+             */
+            template <typename HandlerT>
+            void onFailure(HandlerT handler)
+            {
+                connect(this, &ServerCallBase::failure,
+                        [=]() { handler(results()); });
+            }
+
+        private:
+            void gotReply()
+            {
+                if (readReply())
+                {
+                    const auto data = setup.preprocess(rawData());
+                    if (status().good())
+                        setup.fillResult(data);
+                }
+
+                finish(true);
+            }
+
+        private:
+            SetupT setup;
+    };
+}

--- a/serverapi/servercallsetup.cpp
+++ b/serverapi/servercallsetup.cpp
@@ -23,21 +23,21 @@
 
 using namespace QMatrixClient;
 
-QJsonObject JsonObjectResult::preprocess(QByteArray bytes, CallStatus& status)
+QJsonObject GetJson::preprocess(QByteArray bytes)
 {
     QJsonParseError error;
     QJsonDocument data = QJsonDocument::fromJson(bytes, &error);
     if (error.error != QJsonParseError::NoError)
     {
-        status = { CallStatus::JsonParseError,
+        setStatus( CallStatus::JsonParseError,
                    QObject::tr("Invalid JSON: %1 at offset %2")
                        .arg(error.errorString()).arg(error.offset)
-                 };
+                 );
     }
     if (!data.isObject())
     {
-        status = { CallStatus::JsonParseError,
-                   QObject::tr("The received JSON has no top-level object") };
+        setStatus( CallStatus::JsonParseError,
+                   QObject::tr("The received JSON has no top-level object") );
     }
     return std::move(data.object());
 }

--- a/serverapi/servercallsetup.cpp
+++ b/serverapi/servercallsetup.cpp
@@ -1,0 +1,43 @@
+/******************************************************************************
+ * Copyright (C) 2016 Kitsune Ral <kitsune-ral@users.sf.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "servercallsetup.h"
+
+#include <QtCore/QJsonDocument>
+#include <QtCore/QObject> // For tr()
+
+using namespace QMatrixClient;
+
+QJsonObject JsonObjectResult::preprocess(QByteArray bytes, CallStatus& status)
+{
+    QJsonParseError error;
+    QJsonDocument data = QJsonDocument::fromJson(bytes, &error);
+    if (error.error != QJsonParseError::NoError)
+    {
+        status = { CallStatus::JsonParseError,
+                   QObject::tr("Invalid JSON: %1 at offset %2")
+                       .arg(error.errorString()).arg(error.offset)
+                 };
+    }
+    if (!data.isObject())
+    {
+        status = { CallStatus::JsonParseError,
+                   QObject::tr("The received JSON has no top-level object") };
+    }
+    return std::move(data.object());
+}

--- a/serverapi/servercallsetup.h
+++ b/serverapi/servercallsetup.h
@@ -30,6 +30,7 @@ namespace QMatrixClient
      * of a code, that is described (but not delimited) by the respective enum,
      * and a freeform message.
      *
+     * @see ServerCall, ServerCallSetup
      */
     class CallStatus
     {
@@ -59,9 +60,9 @@ namespace QMatrixClient
     };
 
     // The following two types define two stock result adaptors to be used.
-    // If you write a customer preprocessor, you should define:
+    // If you write a custom adaptor, you should define:
     // - output_type type;
-    // - a function (or a function object equivalent to it):
+    // - a function (or a function object equivalent to it)
     //       output_type preprocess(const QByteArray&, CallStatus&)
     //   The return value can be of a type implicitly castable to output_type
 
@@ -90,7 +91,7 @@ namespace QMatrixClient
     };
 
     // A supplementary base class for ServerCallSetup<> to pass the shared
-    // status to ServerCallBase. Not supposed to be derived from directly.
+    // status to ServerCallBase. Do not derive from it directly, use ServerCallSetup<>.
     class ServerCallSetupBase
     {
         public:
@@ -111,7 +112,6 @@ namespace QMatrixClient
             friend class ServerCallBase;
             // Allow full access to status for the ServerCallBase class and
             // classes derived from ServerCallSetupBase.
-            // in particular sending this reference further on.
             CallStatus* statusPtr() { return &m_status; }
         private:
             QString m_name;

--- a/serverapi/servercallsetup.h
+++ b/serverapi/servercallsetup.h
@@ -1,0 +1,165 @@
+/******************************************************************************
+ * Copyright (C) 2016 Kitsune Ral <kitsune-ral@users.sf.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#pragma once
+
+#include "requestparams.h"
+
+#include <QtCore/QByteArray>
+#include <QtCore/QJsonObject>
+
+namespace QMatrixClient
+{
+    /**
+     * This structure stores status of a server call. The status consists
+     * of a code, that is described (but not delimited) by the respective enum,
+     * and a freeform message.
+     *
+     */
+    class CallStatus
+    {
+        public:
+            enum Code { NoError = 0 // To be compatible with Qt conventions
+                , InfoLevel = 0 // Information codes below
+                , Success = 0
+                , PendingResult = 1
+                , WarningLevel = 50 // Warnings below
+                , ErrorLevel = 100 // Errors below
+                , NetworkError = 100
+                , JsonParseError
+                , TimeoutError
+                , UserDefinedError = 200
+            };
+
+            explicit CallStatus(int c = PendingResult) : code(c) { }
+            CallStatus(int c, QString m) : code(c), message(m) { }
+
+            void set(int c) { code = c; message.clear(); }
+            void set(int c, QString m) { code = c; message = m; }
+
+            bool good() const { return code < WarningLevel; }
+
+            int code;
+            QString message;
+    };
+
+    // The following two types define two stock result adaptors to be used.
+    // If you write a customer preprocessor, you should define:
+    // - output_type type;
+    // - a function (or a function object equivalent to it):
+    //       output_type preprocess(const QByteArray&, CallStatus&)
+    //   The return value can be of a type implicitly castable to output_type
+
+    /**
+     * This no-op adaptor passes the reply contents without any actions.
+     */
+    struct NoResultAdaptor
+    {
+        using output_type = QByteArray;
+        static const QByteArray& preprocess(const QByteArray& bytes,
+                                            CallStatus& /*unused*/)
+        {
+            return bytes;
+        }
+    };
+
+    /**
+     * This adaptor checks the reply contents to be a valid JSON document
+     * that has a single object on the top level, parses the document and
+     * returns the resulting structure wrapped into a QJsonObject.
+     */
+    struct JsonObjectResult
+    {
+        using output_type = QJsonObject;
+        static QJsonObject preprocess(QByteArray bytes, CallStatus& status);
+    };
+
+    // A supplementary base class for ServerCallSetup<> to pass the shared
+    // status to ServerCallBase. Not supposed to be derived from directly.
+    class ServerCallSetupBase
+    {
+        public:
+            ServerCallSetupBase(QString name, RequestParams rp)
+                : m_name(name), m_reqParams(rp)
+            { }
+
+            QString name() const { return m_name; }
+            const RequestParams& requestParams() const { return m_reqParams; }
+
+            const CallStatus status() const { return m_status; }
+
+        protected:
+            void setStatus(int code) { setStatus(CallStatus(code)); }
+            void setStatus(int c, QString m) { setStatus(CallStatus(c,m)); }
+            void setStatus(CallStatus cs) { m_status = cs; }
+
+            friend class ServerCallBase;
+            // Allow full access to status for the ServerCallBase class and
+            // classes derived from ServerCallSetupBase.
+            // in particular sending this reference further on.
+            CallStatus* statusPtr() { return &m_status; }
+        private:
+            QString m_name;
+            RequestParams m_reqParams;
+            CallStatus m_status;
+    };
+
+    /**
+     * This is a base class for setups that describe specific server calls
+     * (to specific endpoints, in particular). Derived classes should pick
+     * an appropriate ResultAdaptorT and implement two things:
+     * - Constructor that initializes ServerCallSetup<> - in particular,
+     *   supplies a valid RequestParams object.
+     * - a function or a function object fillResult that can accept
+     *   preprocessed_type, which is the type produced by the chosen preprocessor
+     *   type (QJsonObject by default).
+     *
+     * @see RequestParams, ServerCall
+     */
+    template <class ResultAdaptorT = JsonObjectResult>
+    class ServerCallSetup : public ServerCallSetupBase
+    {
+        public: // For use in derived classes initialization
+            ServerCallSetup(QString name, RequestParams rp)
+                : ServerCallSetupBase(name, rp)
+            { }
+
+            using HttpType = RequestParams::HttpType;
+            using Query = RequestParams::Query;
+            using Data = RequestParams::Data;
+
+            using preprocessed_type = typename ResultAdaptorT::output_type;
+
+            void fillResult(preprocessed_type)
+            {
+                Q_STATIC_ASSERT_X(true,
+                    "When deriving from ServerCallSetup<>, "
+                    "fillResult(preprocessed_type) should be redefined");
+            }
+
+        public:
+            // If you want to do preprocessing inside the class derived from
+            // ServerCallSetup<>, don't override this; just use NoResultAdaptor
+            // and do preprocessing in fillResult() directly.
+            preprocessed_type preprocess(const QByteArray& bytes)
+            {
+                return std::move(ResultAdaptorT::preprocess(bytes, *statusPtr()));
+            }
+    };
+
+}

--- a/user.cpp
+++ b/user.cpp
@@ -21,11 +21,12 @@
 #include "connection.h"
 #include "events/event.h"
 #include "events/roommemberevent.h"
-#include "jobs/mediathumbnailjob.h"
+#include "serverapi/getmediathumbnail.h"
 
 #include <QtCore/QTimer>
 #include <QtCore/QPair>
 #include <QtCore/QDebug>
+
 
 using namespace QMatrixClient;
 
@@ -132,14 +133,14 @@ void User::requestAvatar()
 
 void User::Private::requestAvatar()
 {
-    MediaThumbnailJob* job =
-            connection->getThumbnail(avatarUrl, requestedWidth, requestedHeight);
-    connect( job, &MediaThumbnailJob::success, [=]() {
-        avatarOngoingRequest = false;
-        avatarValid = true;
-        avatar = job->thumbnail().scaled(requestedWidth, requestedHeight,
-                        Qt::KeepAspectRatio, Qt::SmoothTransformation);
-        scaledMap.clear();
-        emit q->avatarChanged(q);
-    });
+    connection
+        ->callServer(GetMediaThumbnail(avatarUrl, requestedWidth, requestedHeight))
+        ->onSuccess( [=](const GetMediaThumbnail& data) {
+            avatarOngoingRequest = false;
+            avatarValid = true;
+            avatar = data.thumbnail.scaled(requestedWidth, requestedHeight,
+                            Qt::KeepAspectRatio, Qt::SmoothTransformation);
+            scaledMap.clear();
+            emit q->avatarChanged(q);
+        });
 }


### PR DESCRIPTION
Here's some long read, in GitHub, commits and comments, as well as the actual code. Don't be scared by almost a thousand added lines - probably half of them are comments. Quaternion has been tried to run with these changes and it works without any degradation.

Now to the stuff. All new infrastructure is in the first commit. I thought of splitting it into several but quickly ended up with splitting commits by translation units, which is not much helpful in grasping the thing anyway. So I'm putting here a description of all entities worth mention. I was writing a lot of comments in the "client-facing" code, as well.

First, the overall structure. It's basically BaseJob that was split into separate classes:
**RequestParams (requestparams.h)** - encapsulates apiPath(), query, data() methods of BaseJob, but without using virtual functions. These are just parameters, not behaviour, passed to the server - then why don't we make them such. I consider this part useful even if all the rest is scrapped.
**ServerCallSetupBase and ServerCallSetup<> (servercallsetup.*)** - these two classes encapsulate the configuration of a specific server call. ServerCallSetup is passed as parameter to the class that actually executes the job (ServerCall<>, see below); it also receives a type parameter that defines, basically, what kind of result is expected on the input. So far two result adaptors are defined - one for JSON-based responses (it converts QByteArray to QJsonDocument - the part of code that was in BaseJob::gotReply) and a no-op one (used for calls like GetMediaThumbnail - see the second commit). That's where the common status across server call setups and server calls is defined - see below about CallStatus.
Implementing new server calls is done entirely by subclassing ServerCallSetup<> - there's no (shouldn't be) need to take anything from anywhere else in serverapi/. These derived classes become very concise - see passwordlogin.* and getmediathumbnail.* for examples. What should be in a derived class is a constructor (that creates a RequestParams object), member variables that hold the results (there's no need to hide them behind accessors because ServerCall<>::results() method will already return a const reference to this class), and fillResult() method that converts the contents of the network reply (adapted by a result adaptor) into values of these member variables. Actually, the two provided proof-of-concepts illustrate it pretty well, I think.
**CallStatus (servercallsetup.h)** - a simple structure that has a status code and a message. Instead of BaseJob::error(), we now have ServerCallBase::status(). This is shared between a server call setup and a server call - notice the contents of ServerCallBase::init().
**ServerCallBase (servercall.*)** - this is all that remained from BaseJob after I removed everything. There's no KJob - my investigation even before I went to writing all this, led me to feeling that the only actually used code from KJob is its finish method - and even that one does not quite fit the task. So I took the general concept, copied a few pieces here and there (so this class still reminds of BaseJob) but got rid of KJob completely.
What ServerCallBase does is basically packing the QNetworkRequest from RequestParams passed to its doStart() method, and holding (but not handling, except general validation for network errors) the pointer to QNetworkReply. It also sends Qt signals once its finish() method is triggered. This class is a set of tools, but the orchestration is done from ServerCall<> (see below).
**ServerCall<> (servercall.h)** - this template takes SetupT - a type derived from ServerCallSetup<> (see above) - as a parameter and makes a working machine out of SetupT, ServerCallBase and RequestParams. It turned out to be a pretty shallow wrapper around ServerCallBase: most of the definition is taken by utility methods that encapsulate connect() calls, injecting type-converting lambdas along the way. A look at how the result is used in connection.cpp and user.cpp should be enough to understand the idea. These methods are not really essential to the whole thing but I decided to keep them because they do provide some neat convenience - think of packing up the whole call invocation and results processing into a m_connection->callServer(...)->onSuccess(...). Anyway, these can be read, understood and used the last thing.
Speaking of **Connection::callServer()** - this is a handy method to construct the proper server call object (basically by passing a constructed ServerCallSetup derivative to this method) and return a pointer to it. Nothing else, very simple. Don't let std::forward scare you away.

It might make sense to fetch the branch, open it in IDE and navigate through the code a bit. A downside of template objects is that you cannot easily navigate to classes that are their potential parameters. Until C++ gets Concepts onboard, I can't help with it much, unfortunately. Otherwise, going through calls starting from ServerCall<>::start() (or even from Connection::callServer) should tell you the whole story.