### PR TITLE
Make sync failure handler emit loginError instead of connectionError in case of access denial

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -117,8 +117,12 @@ SyncJob* Connection::sync(int timeout)
         d->processRooms(syncJob->roomData());
         emit syncDone();
     });
-    connect( syncJob, &SyncJob::failure,
-             [=] () { emit connectionError(syncJob->errorString());});
+    connect( syncJob, &SyncJob::failure, [=] () {
+        if (syncJob->error() == BaseJob::ContentAccessError)
+            emit loginError(syncJob->errorString());
+        else
+            emit connectionError(syncJob->errorString());
+    });
     syncJob->start();
     return syncJob;
 }


### PR DESCRIPTION
I'm yet to figure out which specific error codes in QNetworkReply better be handled specially but the idea is that Connection::loginError() will trigger a re-login in clients. This changes the interface between the library and the clients, hence the PR.