### PR TITLE
Dropping KCoreAddons

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "kcoreaddons"]
-	path = kcoreaddons
-	url = git://anongit.kde.org/kcoreaddons.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,25 +10,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
 
-# Whether to build with the bundled KCoreAddons or system KCoreAddons
-set( BUNDLE_KCOREADDONS "AUTO" CACHE STRING "Build own KCoreAddons, one of ON, OFF and AUTO" )
-set( KCOREADDONS_DIR "kcoreaddons" CACHE STRING "Local path to bundled KCoreAddons sources, if own KCoreAddons is built" )
-
-find_package(Qt5Core 5.2.0) # For JSON (de)serialization
-find_package(Qt5Network 5.2.0) # For networking
-find_package(Qt5Gui 5.2.0) # For userpics
-
-if ( (NOT BUNDLE_KCOREADDONS STREQUAL "ON")
-     AND (NOT BUNDLE_KCOREADDONS STREQUAL "OFF")
-     AND (NOT BUNDLE_KCOREADDONS STREQUAL "AUTO") )
-       message( FATAL_ERROR "BUNDLE_KCOREADDONS must be one of ON, OFF or AUTO" )
-endif ()
-
-if ( BUNDLE_KCOREADDONS STREQUAL "AUTO" )
-    find_package(KF5CoreAddons QUIET)
-elseif ( BUNDLE_KCOREADDONS STREQUAL "OFF" )
-    find_package(KF5CoreAddons REQUIRED)
-endif ()
 
 message( STATUS )
 message( STATUS "================================================================================" )
@@ -37,14 +18,6 @@ message( STATUS "===============================================================
 message( STATUS "Building with: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}" )
 message( STATUS "Install Prefix: ${CMAKE_INSTALL_PREFIX}" )
 message( STATUS "Path to Qt Core: ${Qt5Core_DIR}" )
-message( STATUS "Build own KCoreAddons (BUNDLE_KCOREADDONS): ${BUNDLE_KCOREADDONS}" )
-if ( NOT BUNDLE_KCOREADDONS STREQUAL "ON" )
-    if ( KF5CoreAddons_FOUND )
-        message( STATUS "'- Path to system KCoreAddons: ${KF5CoreAddons_DIR}" )
-    else ( KF5CoreAddons_FOUND )
-        message( STATUS "'- System KCoreAddons not found, using the bundled version at ${PROJECT_SOURCE_DIR}/${KCOREADDONS_DIR}" )
-    endif ( KF5CoreAddons_FOUND )
-endif ( NOT BUNDLE_KCOREADDONS STREQUAL "ON" )
 message( STATUS "================================================================================" )
 message( STATUS )
 
@@ -80,16 +53,6 @@ set(libqmatrixclient_SRCS
    jobs/mediathumbnailjob.cpp
    jobs/logoutjob.cpp
     )
-# Add bundled KCoreAddons sources if we haven't found the system sources
-# or if we ignore them
-if ( NOT KF5CoreAddons_FOUND )
-    set (libqmatrixclient_SRCS ${libqmatrixclient_SRCS}
-        ${KCOREADDONS_DIR}/src/lib/jobs/kjob.cpp
-        ${KCOREADDONS_DIR}/src/lib/jobs/kcompositejob.cpp
-        ${KCOREADDONS_DIR}/src/lib/jobs/kjobtrackerinterface.cpp
-        ${KCOREADDONS_DIR}/src/lib/jobs/kjobuidelegate.cpp
-        )
-endif ( NOT KF5CoreAddons_FOUND )
 
 add_library(qmatrixclient ${libqmatrixclient_SRCS})
 
@@ -109,14 +72,3 @@ else ( CMAKE_VERSION VERSION_LESS "3.1" )
 endif ( CMAKE_VERSION VERSION_LESS "3.1" )
 
 target_link_libraries(qmatrixclient Qt5::Core Qt5::Network Qt5::Gui)
-if ( KF5CoreAddons_FOUND )
-    # The proper way of doing things would be to make a separate config.h.in
-    # file and use configure_file() command here to generate config.h with
-    # needed C++ preprocessor macros. If we have more than one or two
-    # dependencies like that, we should turn to that more scalable way.
-    # As for now, passing a macro through -D is easier to observe and maintain.
-    target_compile_definitions ( qmatrixclient PRIVATE USING_SYSTEM_KCOREADDONS )
-    target_link_libraries(qmatrixclient KF5::CoreAddons)
-else ( KF5CoreAddons_FOUND )
-    include_directories( ${KCOREADDONS_DIR}/src/lib/jobs )
-endif ( KF5CoreAddons_FOUND )

--- a/connection.cpp
+++ b/connection.cpp
@@ -24,7 +24,6 @@
 #include "room.h"
 #include "jobs/passwordlogin.h"
 #include "jobs/logoutjob.h"
-#include "jobs/geteventsjob.h"
 #include "jobs/postmessagejob.h"
 #include "jobs/postreceiptjob.h"
 #include "jobs/joinroomjob.h"

--- a/connectionprivate.cpp
+++ b/connectionprivate.cpp
@@ -23,7 +23,6 @@
 #include "user.h"
 #include "jobs/passwordlogin.h"
 #include "jobs/syncjob.h"
-#include "jobs/geteventsjob.h"
 #include "jobs/joinroomjob.h"
 #include "jobs/roommembersjob.h"
 #include "events/event.h"

--- a/connectionprivate.cpp
+++ b/connectionprivate.cpp
@@ -116,69 +116,7 @@ Room* ConnectionPrivate::provideRoom(QString id)
     return room;
 }
 
-//void ConnectionPrivate::connectDone(KJob* job)
-//{
-//    PasswordLogin* realJob = static_cast<PasswordLogin*>(job);
-//    if( !realJob->error() )
-//    {
-//        isConnected = true;
-//        userId = realJob->id();
-//        qDebug() << "Our user ID: " << userId;
-//        emit q->connected();
-//    }
-//    else {
-//        emit q->loginError( job->errorString() );
-//    }
-//}
-
-//void ConnectionPrivate::reconnectDone(KJob* job)
-//{
-//    PasswordLogin* realJob = static_cast<PasswordLogin*>(job);
-//    if( !realJob->error() )
-//    {
-//        userId = realJob->id();
-//        emit q->reconnected();
-//    }
-//    else {
-//        emit q->loginError( job->errorString() );
-//        isConnected = false;
-//    }
-//}
-
-//void ConnectionPrivate::syncDone(KJob* job)
-//{
-//    SyncJob* syncJob = static_cast<SyncJob*>(job);
-//    if( !syncJob->error() )
-//    {
-//        data->setLastEvent(syncJob->nextBatch());
-//        processRooms(syncJob->roomData());
-//        emit q->syncDone();
-//    }
-//    else {
-//        if( syncJob->error() == BaseJob::NetworkError )
-//            emit q->connectionError( syncJob->errorString() );
-//        else
-//            qDebug() << "syncJob failed, error:" << syncJob->error();
-//    }
-//}
-
-//void ConnectionPrivate::gotJoinRoom(KJob* job)
-//{
-//    qDebug() << "gotJoinRoom";
-//    JoinRoomJob* joinJob = static_cast<JoinRoomJob*>(job);
-//    if( !joinJob->error() )
-//    {
-//        if ( Room* r = provideRoom(joinJob->roomId()) )
-//            emit q->joinedRoom(r);
-//    }
-//    else
-//    {
-//        if( joinJob->error() == BaseJob::NetworkError )
-//            emit q->connectionError( joinJob->errorString() );
-//    }
-//}
-
-void ConnectionPrivate::gotRoomMembers(KJob* job)
+void ConnectionPrivate::gotRoomMembers(BaseJob* job)
 {
     RoomMembersJob* membersJob = static_cast<RoomMembersJob*>(job);
     if( !membersJob->error() )

--- a/connectionprivate.h
+++ b/connectionprivate.h
@@ -19,15 +19,12 @@
 #ifndef QMATRIXCLIENT_CONNECTIONPRIVATE_H
 #define QMATRIXCLIENT_CONNECTIONPRIVATE_H
 
-class KJob;
-
 #include <QtCore/QObject>
 #include <QtCore/QHash>
 #include <QtCore/QJsonObject>
 
 #include "connection.h"
 #include "connectiondata.h"
-#include "jobs/syncjob.h"
 
 namespace QMatrixClient
 {
@@ -35,6 +32,8 @@ namespace QMatrixClient
     class Event;
     class State;
     class User;
+    class BaseJob;
+    class SyncRoomData;
 
     class ConnectionPrivate : public QObject
     {
@@ -60,11 +59,7 @@ namespace QMatrixClient
             QString userId;
 
         public slots:
-//            void connectDone(KJob* job);
-//            void reconnectDone(KJob* job);
-//            void syncDone(KJob* job);
-//            void gotJoinRoom(KJob* job);
-            void gotRoomMembers(KJob* job);
+            void gotRoomMembers(BaseJob* job);
     };
 }
 

--- a/jobs/basejob.h
+++ b/jobs/basejob.h
@@ -19,12 +19,6 @@
 #ifndef QMATRIXCLIENT_BASEJOB_H
 #define QMATRIXCLIENT_BASEJOB_H
 
-#ifdef USING_SYSTEM_KCOREADDONS
-#include <KCoreAddons/KJob>
-#else
-#include "kjob.h"
-#endif // KCOREADDONS_FOUND
-
 #include <QtCore/QJsonDocument>
 #include <QtCore/QJsonObject>
 #include <QtCore/QUrlQuery>
@@ -36,28 +30,75 @@ namespace QMatrixClient
 
     enum class JobHttpType { GetJob, PutJob, PostJob };
     
-    class BaseJob: public KJob
+    class BaseJob: public QObject
     {
             Q_OBJECT
         public:
+            /* Just in case, the values are compatible with KJob
+             * (which BaseJob used to inherit from). */
+            enum ErrorCode { NoError = 0, NetworkError = 100,
+                             JsonParseError, TimeoutError, ContentAccessError,
+                             UserDefinedError = 512 };
+
             BaseJob(ConnectionData* connection, JobHttpType type,
                     QString name, bool needsToken=true);
             virtual ~BaseJob();
 
-            void start() override;
+            void start();
 
-            enum ErrorCode { NetworkError = KJob::UserDefinedError,
-                             JsonParseError, TimeoutError, ContentAccessError,
-                             UserDefinedError = 512 };
+            /**
+             * Abandons the result of this job, arrived or unarrived.
+             *
+             * This aborts waiting for a reply from the server (if there was
+             * any pending) and deletes the job object. It is always done quietly
+             * (as opposed to KJob::kill() that can trigger emitting the result).
+             */
+            void abandon();
+
+            int error() const;
+            virtual QString errorString() const;
 
         signals:
             /**
-             * Emitted together with KJob::result() but only if there's no error.
+             * Emitted when the job is finished, in any case. It is used to notify
+             * observers that the job is terminated and that progress can be hidden.
+             *
+             * This should not be emitted directly by subclasses;
+             * use emitResult() instead.
+             *
+             * In general, to be notified of a job's completion, client code
+             * should connect to success() and failure()
+             * rather than finished(), so that kill() is indeed quiet.
+             * However if you store a list of jobs and they might get killed
+             * silently, then you must connect to this instead of result(),
+             * to avoid dangling pointers in your list.
+             *
+             * @param job the job that emitted this signal
+             * @internal
+             *
+             * @see success, failure
+             */
+            void finished(BaseJob* job);
+
+            /**
+             * Emitted when the job is finished (except when killed).
+             *
+             * Use error to know if the job was finished with error.
+             *
+             * @param job the job that emitted this signal
+             *
+             * @see success, failure
+             */
+            void result(BaseJob* job);
+
+            /**
+             * Emitted together with result() but only if there's no error.
              */
             void success(BaseJob*);
+
             /**
-             * Emitted together with KJob::result() if there's an error.
-             * Same as result(), this won't be emitted in case of kill(Quietly).
+             * Emitted together with result() if there's an error.
+             * Same as result(), this won't be emitted in case of kill().
              */
             void failure(BaseJob*);
 
@@ -70,6 +111,34 @@ namespace QMatrixClient
             virtual QJsonObject data() const;
             virtual void parseJson(const QJsonDocument& data);
             
+            /**
+             * Sets the error code.
+             *
+             * It should be called when an error is encountered in the job,
+             * just before calling emitResult(). Normally you might want to
+             * use fail() instead - it sets error code, error text, makes sure
+             * the job has finished and invokes emitResult after that.
+             *
+             * To extend the list of error codes, define an (anonymous) enum
+             * with additional values starting at BaseJob::UserDefinedError
+             *
+             * @param errorCode the error code
+             * @see emitResult(), fail()
+             */
+            void setError(int errorCode);
+            void setErrorText(QString errorText);
+
+            /**
+             * Utility function to emit the result signal, and suicide this job.
+             * It first notifies the observers to hide the progress for this job using
+             * the finished() signal.
+             *
+             * @note: Deletes this job using deleteLater().
+             *
+             * @see result()
+             * @see finished()
+             */
+            void emitResult();
             void fail( int errorCode, QString errorString );
             QNetworkReply* networkReply() const;
 
@@ -79,10 +148,9 @@ namespace QMatrixClient
             void timeout();
             void sslErrors(const QList<QSslError>& errors);
 
-            //void networkError(QNetworkReply::NetworkError code);
-
-
         private:
+            void finishJob(bool emitResult);
+
             class Private;
             Private* d;
     };

--- a/jobs/checkauthmethods.cpp
+++ b/jobs/checkauthmethods.cpp
@@ -57,7 +57,7 @@ QString CheckAuthMethods::apiPath() const
     return "_matrix/client/r0/login";
 }
 
-void CheckAuthMethods::parseJson(const QJsonDocument& data)
+BaseJob::Status CheckAuthMethods::parseJson(const QJsonDocument& data)
 {
     // TODO
 }

--- a/jobs/checkauthmethods.h
+++ b/jobs/checkauthmethods.h
@@ -35,7 +35,7 @@ namespace QMatrixClient
             
         protected:
             QString apiPath() const override;
-            void parseJson(const QJsonDocument& data) override;
+            Status parseJson(const QJsonDocument& data) override;
             
         private:
             class Private;

--- a/jobs/joinroomjob.cpp
+++ b/jobs/joinroomjob.cpp
@@ -54,18 +54,15 @@ QString JoinRoomJob::apiPath() const
     return QString("_matrix/client/r0/join/%1").arg(d->roomAlias);
 }
 
-void JoinRoomJob::parseJson(const QJsonDocument& data)
+BaseJob::Status JoinRoomJob::parseJson(const QJsonDocument& data)
 {
     QJsonObject json = data.object();
-    if( !json.contains("room_id") )
-    {
-        fail( BaseJob::UserDefinedError, "Something went wrong..." );
-        qDebug() << data;
-        return;
-    }
-    else
+    if( json.contains("room_id") )
     {
         d->roomId = json.value("room_id").toString();
+        return Success;
     }
-    emitResult();
+
+    qDebug() << data;
+    return { UserDefinedError, "No room_id in the JSON response" };
 }

--- a/jobs/joinroomjob.h
+++ b/jobs/joinroomjob.h
@@ -35,7 +35,7 @@ namespace QMatrixClient
 
             protected:
                 QString apiPath() const override;
-                void parseJson(const QJsonDocument& data) override;
+                Status parseJson(const QJsonDocument& data) override;
 
             private:
                 class Private;

--- a/jobs/mediathumbnailjob.cpp
+++ b/jobs/mediathumbnailjob.cpp
@@ -70,17 +70,9 @@ QUrlQuery MediaThumbnailJob::query() const
     return query;
 }
 
-void MediaThumbnailJob::gotReply()
+void MediaThumbnailJob::parseReply(QByteArray data)
 {
-    if( networkReply()->error() != QNetworkReply::NoError )
-    {
-        qDebug() << "NetworkError!!!";
-        qDebug() << networkReply()->errorString();
-        fail( NetworkError, networkReply()->errorString() );
-        return;
-    }
-
-    if( !d->thumbnail.loadFromData( networkReply()->readAll() ) )
+    if( !d->thumbnail.loadFromData(data) )
     {
         qDebug() << "MediaThumbnailJob: could not read image data";
     }

--- a/jobs/mediathumbnailjob.cpp
+++ b/jobs/mediathumbnailjob.cpp
@@ -70,11 +70,11 @@ QUrlQuery MediaThumbnailJob::query() const
     return query;
 }
 
-void MediaThumbnailJob::parseReply(QByteArray data)
+BaseJob::Status MediaThumbnailJob::parseReply(QByteArray data)
 {
     if( !d->thumbnail.loadFromData(data) )
     {
         qDebug() << "MediaThumbnailJob: could not read image data";
     }
-    emitResult();
+    return Success;
 }

--- a/jobs/mediathumbnailjob.h
+++ b/jobs/mediathumbnailjob.h
@@ -40,8 +40,7 @@ namespace QMatrixClient
             QString apiPath() const override;
             QUrlQuery query() const override;
 
-        protected slots:
-            void gotReply() override;
+            virtual void parseReply(QByteArray data) override;
 
         private:
             class Private;

--- a/jobs/mediathumbnailjob.h
+++ b/jobs/mediathumbnailjob.h
@@ -40,7 +40,7 @@ namespace QMatrixClient
             QString apiPath() const override;
             QUrlQuery query() const override;
 
-            virtual void parseReply(QByteArray data) override;
+            Status parseReply(QByteArray data) override;
 
         private:
             class Private;

--- a/jobs/passwordlogin.cpp
+++ b/jobs/passwordlogin.cpp
@@ -80,15 +80,15 @@ QJsonObject PasswordLogin::data() const
     return json;
 }
 
-void PasswordLogin::parseJson(const QJsonDocument& data)
+BaseJob::Status PasswordLogin::parseJson(const QJsonDocument& data)
 {
     QJsonObject json = data.object();
     if( !json.contains("access_token") || !json.contains("home_server") || !json.contains("user_id") )
     {
-        fail( BaseJob::UserDefinedError, "Unexpected data" );
+        return { UserDefinedError, "No expected data" };
     }
     d->returned_token = json.value("access_token").toString();
     d->returned_server = json.value("home_server").toString();
     d->returned_id = json.value("user_id").toString();
-    emitResult();
+    return Success;
 }

--- a/jobs/passwordlogin.h
+++ b/jobs/passwordlogin.h
@@ -38,7 +38,7 @@ namespace QMatrixClient
         protected:
             QString apiPath() const override;
             QJsonObject data() const override;
-            void parseJson(const QJsonDocument& data) override;
+            Status parseJson(const QJsonDocument& data) override;
 
         private:
             class Private;

--- a/jobs/postmessagejob.cpp
+++ b/jobs/postmessagejob.cpp
@@ -61,14 +61,11 @@ QJsonObject PostMessageJob::data() const
     return json;
 }
 
-void PostMessageJob::parseJson(const QJsonDocument& data)
+BaseJob::Status PostMessageJob::parseJson(const QJsonDocument& data)
 {
-    QJsonObject json = data.object();
-    if( !json.contains("event_id") )
-    {
-        fail( BaseJob::UserDefinedError, "Something went wrong..." );
-        qDebug() << data;
-        return;
-    }
-    emitResult();
+    if( data.object().contains("event_id") )
+        return Success;
+
+    qDebug() << data;
+    return { UserDefinedError, "No event_id in the JSON response" };
 }

--- a/jobs/postmessagejob.h
+++ b/jobs/postmessagejob.h
@@ -35,7 +35,7 @@ namespace QMatrixClient
         protected:
             QString apiPath() const override;
             QJsonObject data() const override;
-            void parseJson(const QJsonDocument& data) override;
+            Status parseJson(const QJsonDocument& data) override;
 
         private:
             class Private;

--- a/jobs/roommembersjob.cpp
+++ b/jobs/roommembersjob.cpp
@@ -56,10 +56,9 @@ QString RoomMembersJob::apiPath() const
     return QString("_matrix/client/r0/rooms/%1/members").arg(d->room->id());
 }
 
-void RoomMembersJob::parseJson(const QJsonDocument& data)
+BaseJob::Status RoomMembersJob::parseJson(const QJsonDocument& data)
 {
-    QJsonObject obj = data.object();
-    QJsonArray chunk = obj.value("chunk").toArray();
+    QJsonArray chunk = data.object().value("chunk").toArray();
     for( const QJsonValue& val : chunk )
     {
         State* state = State::fromJson(val.toObject());
@@ -67,5 +66,5 @@ void RoomMembersJob::parseJson(const QJsonDocument& data)
             d->states.append(state);
     }
     qDebug() << "States: " << d->states.count();
-    emitResult();
+    return Success;
 }

--- a/jobs/roommembersjob.h
+++ b/jobs/roommembersjob.h
@@ -35,8 +35,8 @@ namespace QMatrixClient
             QList<State*> states();
 
         protected:
-            virtual QString apiPath() const override;
-            virtual void parseJson(const QJsonDocument& data) override;
+            QString apiPath() const override;
+            Status parseJson(const QJsonDocument& data) override;
 
         private:
             class Private;

--- a/jobs/roommessagesjob.cpp
+++ b/jobs/roommessagesjob.cpp
@@ -81,10 +81,10 @@ QUrlQuery RoomMessagesJob::query() const
     return query;
 }
 
-void RoomMessagesJob::parseJson(const QJsonDocument& data)
+BaseJob::Status RoomMessagesJob::parseJson(const QJsonDocument& data)
 {
     QJsonObject obj = data.object();
     d->events = eventListFromJson(obj.value("chunk").toArray());
     d->end = obj.value("end").toString();
-    emitResult();
+    return Success;
 }

--- a/jobs/roommessagesjob.h
+++ b/jobs/roommessagesjob.h
@@ -40,7 +40,7 @@ namespace QMatrixClient
         protected:
             QString apiPath() const override;
             QUrlQuery query() const override;
-            void parseJson(const QJsonDocument& data) override;
+            Status parseJson(const QJsonDocument& data) override;
 
         private:
             class Private;

--- a/jobs/syncjob.cpp
+++ b/jobs/syncjob.cpp
@@ -110,7 +110,7 @@ QUrlQuery SyncJob::query() const
     return query;
 }
 
-void SyncJob::parseJson(const QJsonDocument& data)
+BaseJob::Status SyncJob::parseJson(const QJsonDocument& data)
 {
     QJsonObject json = data.object();
     d->nextBatch = json.value("next_batch").toString();
@@ -134,8 +134,7 @@ void SyncJob::parseJson(const QJsonDocument& data)
         }
     }
 
-    emitResult();
-    qDebug() << objectName() << ": processing complete";
+    return Success;
 }
 
 void SyncRoomData::EventList::fromJson(const QJsonObject& roomContents)

--- a/jobs/syncjob.h
+++ b/jobs/syncjob.h
@@ -73,7 +73,7 @@ namespace QMatrixClient
         protected:
             QString apiPath() const override;
             QUrlQuery query() const override;
-            void parseJson(const QJsonDocument& data) override;
+            Status parseJson(const QJsonDocument& data) override;
 
         private:
             class Private;

--- a/libqmatrixclient.pri
+++ b/libqmatrixclient.pri
@@ -32,10 +32,7 @@ HEADERS += \
     $$PWD/jobs/roommessagesjob.h \
     $$PWD/jobs/syncjob.h \
     $$PWD/jobs/mediathumbnailjob.h \
-    $$PWD/kcoreaddons/src/lib/jobs/kjob.h \
-    $$PWD/kcoreaddons/src/lib/jobs/kcompositejob.h \
-    $$PWD/kcoreaddons/src/lib/jobs/kjobtrackerinterface.h \
-    $$PWD/kcoreaddons/src/lib/jobs/kjobuidelegate.h
+    $$PWD/jobs/logoutjob.h
 
 SOURCES += \
     $$PWD/connectiondata.cpp \
@@ -66,7 +63,4 @@ SOURCES += \
     $$PWD/jobs/roommessagesjob.cpp \
     $$PWD/jobs/syncjob.cpp \
     $$PWD/jobs/mediathumbnailjob.cpp \
-    $$PWD/kcoreaddons/src/lib/jobs/kjob.cpp \
-    $$PWD/kcoreaddons/src/lib/jobs/kcompositejob.cpp \
-    $$PWD/kcoreaddons/src/lib/jobs/kjobtrackerinterface.cpp \
-    $$PWD/kcoreaddons/src/lib/jobs/kjobuidelegate.cpp
+    $$PWD/jobs/logoutjob.cpp


### PR DESCRIPTION
Well, the title says it, see the commits for your review. In my case, even the first commit dealt with Fxrh/Quaternion#31 - Quaternion didn't hang/crash after closing the main window anymore. I'm not sure if it's due to something getting stuck inside KJob or (slightly) more rigorous abort()ing of QNetworkReplies in the updated BaseJob.
The second commit provides a better framework for the derived jobs (while I'm still hoping to see #12  merged into master) and manages QNetworkReply in a cleaner way by means of QScopedPointer. Now in order to properly abandon the reply it's enough to reset the pointer to it.

One thing that didn't land in here (yet) is taking emitResult()/fail() invocations out of parseJson() calls. I already stumbled over this a couple of times when a job just waits for a timeout without emitting a result because nobody asked it to do that - and BaseJob::parseJson() didn't even emitResult() on its own until recently. I suppose I'll fetch another page from #12 here: replace setError() + setErrorText() with a single setStatus() call and oblige parseJson() methods to return the status. This will slightly ease deriving from BaseJob. I'll send one more commit into this PR soon.