### PR TITLE
Replaced QList<> with QVector<> where appropriate + minor code cleanup

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -113,7 +113,11 @@ SyncJob* Connection::sync(int timeout)
     syncJob->setTimeout(timeout);
     connect( syncJob, &SyncJob::success, [=] () {
         d->data->setLastEvent(syncJob->nextBatch());
-        d->processRooms(syncJob->roomData());
+        for( const auto roomData: syncJob->roomData() )
+        {
+            if ( Room* r = d->provideRoom(roomData.roomId) )
+                r->updateData(roomData);
+        }
         emit syncDone();
     });
     connect( syncJob, &SyncJob::failure, [=] () {

--- a/connectionprivate.cpp
+++ b/connectionprivate.cpp
@@ -85,15 +85,6 @@ void ConnectionPrivate::processState(State* state)
         r->addInitialState(state);
 }
 
-void ConnectionPrivate::processRooms(const QList<SyncRoomData>& data)
-{
-    for( const SyncRoomData& roomData: data )
-    {
-        if ( Room* r = provideRoom(roomData.roomId) )
-            r->updateData(roomData);
-    }
-}
-
 Room* ConnectionPrivate::provideRoom(QString id)
 {
     if (id.isEmpty())

--- a/connectionprivate.h
+++ b/connectionprivate.h
@@ -46,7 +46,7 @@ namespace QMatrixClient
             void resolveServer( QString domain );
 
             void processState( State* state );
-            void processRooms( const QList<SyncRoomData>& data );
+
             /** Finds a room with this id or creates a new one and adds it to roomMap. */
             Room* provideRoom( QString id );
 

--- a/events/receiptevent.h
+++ b/events/receiptevent.h
@@ -31,9 +31,8 @@ namespace QMatrixClient
             QString eventId;
             QString userId;
             QDateTime timestamp;
-
-            Receipt(QString event, QString user, QDateTime time);
     };
+    using Receipts = QVector<Receipt>;
 
     class ReceiptEvent: public Event
     {
@@ -41,7 +40,7 @@ namespace QMatrixClient
             ReceiptEvent();
             virtual ~ReceiptEvent();
 
-            QList<Receipt> receiptsForEvent(QString eventId) const;
+            Receipts receiptsForEvent(QString eventId) const;
 
             QStringList events() const;
 
@@ -52,5 +51,6 @@ namespace QMatrixClient
             Private* d;
     };
 }
+Q_DECLARE_TYPEINFO(QMatrixClient::Receipt, Q_MOVABLE_TYPE);
 
 #endif // QMATRIXCLIENT_RECEIPTEVENT_H

--- a/jobs/syncjob.cpp
+++ b/jobs/syncjob.cpp
@@ -40,7 +40,7 @@ class SyncJob::Private
         int timeout;
         QString nextBatch;
 
-        QList<SyncRoomData> roomData;
+        SyncData roomData;
 };
 
 static size_t jobId = 0;
@@ -84,7 +84,7 @@ QString SyncJob::nextBatch() const
     return d->nextBatch;
 }
 
-QList<SyncRoomData> SyncJob::roomData() const
+const SyncData& SyncJob::roomData() const
 {
     return d->roomData;
 }
@@ -128,9 +128,9 @@ void SyncJob::parseJson(const QJsonDocument& data)
     {
         const QJsonObject rs = rooms.value(roomState.jsonKey).toObject();
         d->roomData.reserve(rs.size());
-        for( auto r = rs.begin(); r != rs.end(); ++r )
+        for( auto rkey: rs.keys() )
         {
-            d->roomData.push_back({r.key(), r.value().toObject(), roomState.enumVal});
+            d->roomData.push_back({rkey, roomState.enumVal, rs[rkey].toObject()});
         }
     }
 
@@ -144,7 +144,7 @@ void SyncRoomData::EventList::fromJson(const QJsonObject& roomContents)
     swap(l);
 }
 
-SyncRoomData::SyncRoomData(QString roomId_, const QJsonObject& room_, JoinState joinState_)
+SyncRoomData::SyncRoomData(QString roomId_, JoinState joinState_, const QJsonObject& room_)
     : roomId(roomId_)
     , joinState(joinState_)
     , state("state")

--- a/jobs/syncjob.h
+++ b/jobs/syncjob.h
@@ -52,8 +52,11 @@ namespace QMatrixClient
         int highlightCount;
         int notificationCount;
 
-        SyncRoomData(QString roomId_, const QJsonObject& room_, JoinState joinState_);
+        SyncRoomData(QString roomId_ = QString(),
+                     JoinState joinState_ = JoinState::Join,
+                     const QJsonObject& room_ = QJsonObject());
     };
+    using SyncData = QVector<SyncRoomData>;
 
     class ConnectionData;
     class SyncJob: public BaseJob
@@ -67,7 +70,7 @@ namespace QMatrixClient
             void setPresence(QString presence);
             void setTimeout(int timeout);
 
-            QList<SyncRoomData> roomData() const;
+            const SyncData& roomData() const;
             QString nextBatch() const;
 
         protected:
@@ -80,5 +83,6 @@ namespace QMatrixClient
             Private* d;
     };
 }
+Q_DECLARE_TYPEINFO(QMatrixClient::SyncRoomData, Q_MOVABLE_TYPE);
 
 #endif // QMATRIXCLIENT_SYNCJOB_H

--- a/room.cpp
+++ b/room.cpp
@@ -482,11 +482,11 @@ void Room::processEphemeralEvent(Event* event)
     }
     if( event->type() == EventType::Receipt )
     {
-        ReceiptEvent* receiptEvent = static_cast<ReceiptEvent*>(event);
+        auto receiptEvent = static_cast<ReceiptEvent*>(event);
         for( QString eventId: receiptEvent->events() )
         {
-            QList<Receipt> receipts = receiptEvent->receiptsForEvent(eventId);
-            for( Receipt r: receipts )
+            const auto receipts = receiptEvent->receiptsForEvent(eventId);
+            for( const Receipt r: receipts )
             {
                 d->lastReadEvent.insert(d->connection->user(r.userId), eventId);
             }


### PR DESCRIPTION
See https://marcmutz.wordpress.com/effective-qt/containers/ for the background and http://lists.qt-project.org/pipermail/development/2015-July/022283.html for the relevant flamewar in Qt dev mailing list. It's a long read but it boils down to the poor legacy of `QList`: historically it was a linked list but then has been "optimized" to store data in an array instead; as a result, now it's some strange container between a vector, a deque, and a linked list, losing in any respect if something bigger than a pointer is stored in it. Therefore I replaced `QList` with `QVector` in the two "something bigger than a pointer" cases. That required to make the respective structures default-constructible and memmovable, though - but that's a good thing for those anyway.