### PR TITLE
Enable Travis CI for libqmatrixclient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -y qt5-default
- - if [ "$INSTALL_KCOREADDONS" = true ]; then git clone git://anongit.kde.org/extra-cmake-modules.git ecm && cd ecm && git checkout v5.18.0 && cmake . && make && sudo make install && cd ..; fi
+ - if [ "$INSTALL_KCOREADDONS" = true ]; then git clone git://anongit.kde.org/extra-cmake-modules.git ecm && cd ecm && git checkout v5.20.0 && cmake . && make && sudo make install && cd ..; fi
  - if [ "$INSTALL_KCOREADDONS" = true ]; then git clone git://anongit.kde.org/kcoreaddons.git kca && cd kca && git checkout 7ac7a605923f0bb2f0f367f6069a101a24bead9f && cmake . && make && sudo make install && cd ..; fi
 install:
  - git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
 dist: trusty
 language: cpp
-env:
- - INSTALL_KCOREADDONS=true
- - INSTALL_KCOREADDONS=false
+compiler:
+ - gcc
+ - clang
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -y qt5-default
- - if [ "$INSTALL_KCOREADDONS" = true ]; then git clone git://anongit.kde.org/extra-cmake-modules.git ecm && cd ecm && git checkout v5.20.0 && cmake . && make && sudo make install && cd ..; fi
- - if [ "$INSTALL_KCOREADDONS" = true ]; then git clone git://anongit.kde.org/kcoreaddons.git kca && cd kca && git checkout 7ac7a605923f0bb2f0f367f6069a101a24bead9f && cmake . && make && sudo make install && cd ..; fi
 install:
- - git submodule update --init --recursive
  - mkdir build && cd build
- - cmake ../
- - make
-script: true
+ - cmake ..
+script:
+ - cmake --build . --target all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+dist: trusty
+language: cpp
+env:
+ - INSTALL_KCOREADDONS=true
+ - INSTALL_KCOREADDONS=false
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install -y qt5-default
+ - if [ "$INSTALL_KCOREADDONS" = true ]; then git clone git://anongit.kde.org/extra-cmake-modules.git ecm && cd ecm && git checkout 5.18.0 && cmake . && make && sudo make install && cd ..; fi
+ - if [ "$INSTALL_KCOREADDONS" = true ]; then git clone git://anongit.kde.org/kcoreaddons.git kca && cd kca && git checkout 7ac7a605923f0bb2f0f367f6069a101a24bead9f && cmake . && make && sudo make install && cd ..; fi
+install:
+ - git submodule update --init --recursive
+ - mkdir build && cd build
+ - cmake ../
+ - make
+script: true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -y qt5-default
- - if [ "$INSTALL_KCOREADDONS" = true ]; then git clone git://anongit.kde.org/extra-cmake-modules.git ecm && cd ecm && git checkout 5.18.0 && cmake . && make && sudo make install && cd ..; fi
+ - if [ "$INSTALL_KCOREADDONS" = true ]; then git clone git://anongit.kde.org/extra-cmake-modules.git ecm && cd ecm && git checkout v5.18.0 && cmake . && make && sudo make install && cd ..; fi
  - if [ "$INSTALL_KCOREADDONS" = true ]; then git clone git://anongit.kde.org/kcoreaddons.git kca && cd kca && git checkout 7ac7a605923f0bb2f0f367f6069a101a24bead9f && cmake . && make && sudo make install && cd ..; fi
 install:
  - git submodule update --init --recursive


### PR DESCRIPTION
Without KCoreAddons, this is now easily buildable with the stock _trusty_ codebase. There's a good question though if it should rather build Fxrh/Quaternion against this commit (with build success being an advisory rather than a strict condition). Or we'd just make some auto-tests for it, already...