### PR TITLE
RoomMessageEvent refactoring, take 2

### DIFF
--- a/events/roommessageevent.cpp
+++ b/events/roommessageevent.cpp
@@ -70,6 +70,18 @@ MessageEventContent::Base* RoomMessageEvent::content() const
     return d->content;
 }
 
+template <class ContentT>
+MessageEventContent::Base* make(const QJsonObject& json)
+{
+    return new ContentT(json);
+}
+
+template <class ContentT>
+MessageEventContent::Base* make2(const QJsonObject& json)
+{
+    return new ContentT(json["url"].toString(), json["info"].toObject());
+};
+
 RoomMessageEvent* RoomMessageEvent::fromJson(const QJsonObject& obj)
 {
     RoomMessageEvent* e = new RoomMessageEvent();
@@ -82,104 +94,53 @@ RoomMessageEvent* RoomMessageEvent::fromJson(const QJsonObject& obj)
     }
     if( obj.contains("content") )
     {
-        using namespace MessageEventContent;
+        const QJsonObject content = obj["content"].toObject();
+        if ( content.contains("msgtype") && content.contains("body") )
+        {
+            using namespace MessageEventContent;
 
-        QJsonObject content = obj.value("content").toObject();
-        QString msgtype = content.value("msgtype").toString();
+            e->d->plainBody = content["body"].toString();
 
-        if( msgtype == "m.text" )
-        {
-            e->d->msgtype = MessageEventType::Text;
-            e->d->content = new TextContent(obj);
-        }
-        else if( msgtype == "m.emote" )
-        {
-            e->d->msgtype = MessageEventType::Emote;
-            e->d->content = new TextContent(obj);
-        }
-        else if( msgtype == "m.notice" )
-        {
-            e->d->msgtype = MessageEventType::Notice;
-            e->d->content = new TextContent(obj);
-        }
-        else if( msgtype == "m.image" )
-        {
-            e->d->msgtype = MessageEventType::Image;
-            ImageContent* c = new ImageContent;
-            c->url = QUrl(content.value("url").toString());
-            QJsonObject info = content.value("info").toObject();
-            c->height = info.value("h").toInt();
-            c->width = info.value("w").toInt();
-            c->size = info.value("size").toInt();
-            c->mimetype = info.value("mimetype").toString();
-            e->d->content = c;
-        }
-        else if( msgtype == "m.file" )
-        {
-            e->d->msgtype = MessageEventType::File;
-            FileContent* c = new FileContent;
-            c->filename = content.value("filename").toString();
-            c->url = QUrl(content.value("url").toString());
-            QJsonObject info = content.value("info").toObject();
-            c->size = info.value("size").toInt();
-            c->mimetype = info.value("mimetype").toString();
-            e->d->content = c;
-        }
-        else if( msgtype == "m.location" )
-        {
-            e->d->msgtype = MessageEventType::Location;
-            LocationContent* c = new LocationContent;
-            c->geoUri = content.value("geo_uri").toString();
-            c->thumbnailUrl = QUrl(content.value("thumbnail_url").toString());
-            QJsonObject info = content.value("thumbnail_info").toObject();
-            c->thumbnailHeight = info.value("h").toInt();
-            c->thumbnailWidth = info.value("w").toInt();
-            c->thumbnailSize = info.value("size").toInt();
-            c->thumbnailMimetype = info.value("mimetype").toString();
-            e->d->content = c;
-        }
-        else if( msgtype == "m.video" )
-        {
-            e->d->msgtype = MessageEventType::Video;
-            VideoContent* c = new VideoContent;
-            c->url = QUrl(content.value("url").toString());
-            QJsonObject info = content.value("info").toObject();
-            c->height = info.value("h").toInt();
-            c->width = info.value("w").toInt();
-            c->duration = info.value("duration").toInt();
-            c->size = info.value("size").toInt();
-            c->thumbnailUrl = QUrl(info.value("thumnail_url").toString());
-            QJsonObject thumbnailInfo = content.value("thumbnail_info").toObject();
-            c->thumbnailHeight = thumbnailInfo.value("h").toInt();
-            c->thumbnailWidth = thumbnailInfo.value("w").toInt();
-            c->thumbnailSize = thumbnailInfo.value("size").toInt();
-            c->thumbnailMimetype = thumbnailInfo.value("mimetype").toString();
-            e->d->content = c;
-        }
-        else if( msgtype == "m.audio" )
-        {
-            e->d->msgtype = MessageEventType::Audio;
-            AudioContent* c = new AudioContent;
-            c->url = QUrl(content.value("url").toString());
-            QJsonObject info = content.value("info").toObject();
-            c->duration = info.value("duration").toInt();
-            c->mimetype = info.value("mimetype").toString();
-            c->size = info.value("size").toInt();
-            e->d->content = c;
+            struct Factory
+            {
+                QString jsonTag;
+                MessageEventType enumTag;
+                MessageEventContent::Base*(*make)(const QJsonObject& json);
+            };
+
+            const Factory factories[] {
+                { "m.text", MessageEventType::Text, make<TextContent> },
+                { "m.emote", MessageEventType::Emote, make<TextContent> },
+                { "m.notice", MessageEventType::Notice, make<TextContent> },
+                { "m.image", MessageEventType::Image, make<ImageContent> },
+                { "m.file", MessageEventType::File, make<FileContent> },
+                { "m.location", MessageEventType::Location, make<LocationContent> },
+                { "m.video", MessageEventType::Video, make2<VideoContent> },
+                { "m.audio", MessageEventType::Audio, make2<AudioContent> },
+                // Insert new message types before this line
+            };
+
+            QString msgtype = content.value("msgtype").toString();
+            for (auto f: factories)
+            {
+                if (msgtype == f.jsonTag)
+                {
+                    e->d->msgtype = f.enumTag;
+                    e->d->content = f.make(content);
+                    break;
+                }
+            }
+            if (e->d->msgtype == MessageEventType::Unknown)
+            {
+                qDebug() << "RoomMessageEvent: unknown msgtype: " << msgtype;
+                qDebug() << obj;
+                e->d->content = new Base;
+            }
         }
         else
         {
-            qDebug() << "RoomMessageEvent: unknown msgtype: " << msgtype;
+            qWarning() << "RoomMessageEvent(" << e->id() << "): no body or msgtype";
             qDebug() << obj;
-            e->d->msgtype = MessageEventType::Unknown;
-            e->d->content = new Base;
-        }
-
-        if( content.contains("body") )
-        {
-            e->d->plainBody = content.value("body").toString();
-        } else {
-            qDebug() << "RoomMessageEvent: body not found";
         }
     }
     return e;
@@ -203,3 +164,37 @@ TextContent::TextContent(const QJsonObject& json)
         mimeType = db.mimeTypeForData(body.toUtf8());
     }
 }
+
+FileInfo::FileInfo(QUrl u, const QJsonObject& infoJson, QString originalFilename)
+    : url(u)
+    , fileSize(infoJson["size"].toInt())
+    , mimetype(QMimeDatabase().mimeTypeForName(infoJson["mimetype"].toString()))
+    , originalName(originalFilename)
+{
+    if (!mimetype.isValid())
+        mimetype = QMimeDatabase().mimeTypeForData(QByteArray());
+}
+
+ImageInfo::ImageInfo(QUrl u, const QJsonObject& infoJson)
+    : FileInfo(u, infoJson)
+    , imageSize(infoJson["w"].toInt(), infoJson["h"].toInt())
+{ }
+
+LocationContent::LocationContent(const QJsonObject& json)
+    : geoUri(json["geo_uri"].toString())
+    , thumbnail(json["thumbnail_url"].toString(),
+                json["thumbnail_info"].toObject())
+{ }
+
+VideoContent::VideoContent(QUrl u, const QJsonObject& infoJson)
+    : FileInfo(u, infoJson)
+    , duration(infoJson["duration"].toInt())
+    , imageSize(infoJson["w"].toInt(), infoJson["h"].toInt())
+    , thumbnail(infoJson["thumbnail_url"].toString(),
+                infoJson["thumbnail_info"].toObject())
+{ }
+
+AudioContent::AudioContent(QUrl u, const QJsonObject& infoJson)
+    : FileInfo(u, infoJson)
+    , duration(infoJson["duration"].toInt())
+{ }

--- a/events/roommessageevent.cpp
+++ b/events/roommessageevent.cpp
@@ -31,6 +31,7 @@ class RoomMessageEvent::Private
         
         QString userId;
         MessageEventType msgtype;
+        QString plainBody;
         QDateTime hsob_ts;
         MessageEventContent::Base* content;
 };
@@ -57,9 +58,14 @@ MessageEventType RoomMessageEvent::msgtype() const
     return d->msgtype;
 }
 
+QString RoomMessageEvent::plainBody() const
+{
+    return d->plainBody;
+}
+
 QString RoomMessageEvent::body() const
 {
-    return d->content->body;
+    return plainBody();
 }
 
 QDateTime RoomMessageEvent::hsob_ts() const
@@ -179,7 +185,7 @@ RoomMessageEvent* RoomMessageEvent::fromJson(const QJsonObject& obj)
 
         if( content.contains("body") )
         {
-            e->d->content->body = content.value("body").toString();
+            e->d->plainBody = content.value("body").toString();
         } else {
             qDebug() << "RoomMessageEvent: body not found";
         }

--- a/events/roommessageevent.cpp
+++ b/events/roommessageevent.cpp
@@ -32,7 +32,7 @@ class RoomMessageEvent::Private
         QString userId;
         MessageEventType msgtype;
         QDateTime hsob_ts;
-        MessageEventContent* content;
+        MessageEventContent::Base* content;
 };
 
 RoomMessageEvent::RoomMessageEvent()
@@ -67,9 +67,9 @@ QDateTime RoomMessageEvent::hsob_ts() const
     return d->hsob_ts;
 }
 
-MessageEventContent* RoomMessageEvent::content() const
+MessageEventContent::Base* RoomMessageEvent::content() const
 {
-        return d->content;
+    return d->content;
 }
 
 RoomMessageEvent* RoomMessageEvent::fromJson(const QJsonObject& obj)
@@ -84,28 +84,30 @@ RoomMessageEvent* RoomMessageEvent::fromJson(const QJsonObject& obj)
     }
     if( obj.contains("content") )
     {
+        using namespace MessageEventContent;
+
         QJsonObject content = obj.value("content").toObject();
         QString msgtype = content.value("msgtype").toString();
 
         if( msgtype == "m.text" )
         {
             e->d->msgtype = MessageEventType::Text;
-            e->d->content = new MessageEventContent();
+            e->d->content = new Base();
         }
         else if( msgtype == "m.emote" )
         {
             e->d->msgtype = MessageEventType::Emote;
-            e->d->content = new MessageEventContent();
+            e->d->content = new Base();
         }
         else if( msgtype == "m.notice" )
         {
             e->d->msgtype = MessageEventType::Notice;
-            e->d->content = new MessageEventContent();
+            e->d->content = new Base();
         }
         else if( msgtype == "m.image" )
         {
             e->d->msgtype = MessageEventType::Image;
-            ImageEventContent* c = new ImageEventContent;
+            ImageContent* c = new ImageContent;
             c->url = QUrl(content.value("url").toString());
             QJsonObject info = content.value("info").toObject();
             c->height = info.value("h").toInt();
@@ -117,7 +119,7 @@ RoomMessageEvent* RoomMessageEvent::fromJson(const QJsonObject& obj)
         else if( msgtype == "m.file" )
         {
             e->d->msgtype = MessageEventType::File;
-            FileEventContent* c = new FileEventContent;
+            FileContent* c = new FileContent;
             c->filename = content.value("filename").toString();
             c->url = QUrl(content.value("url").toString());
             QJsonObject info = content.value("info").toObject();
@@ -128,7 +130,7 @@ RoomMessageEvent* RoomMessageEvent::fromJson(const QJsonObject& obj)
         else if( msgtype == "m.location" )
         {
             e->d->msgtype = MessageEventType::Location;
-            LocationEventContent* c = new LocationEventContent;
+            LocationContent* c = new LocationContent;
             c->geoUri = content.value("geo_uri").toString();
             c->thumbnailUrl = QUrl(content.value("thumbnail_url").toString());
             QJsonObject info = content.value("thumbnail_info").toObject();
@@ -141,7 +143,7 @@ RoomMessageEvent* RoomMessageEvent::fromJson(const QJsonObject& obj)
         else if( msgtype == "m.video" )
         {
             e->d->msgtype = MessageEventType::Video;
-            VideoEventContent* c = new VideoEventContent;
+            VideoContent* c = new VideoContent;
             c->url = QUrl(content.value("url").toString());
             QJsonObject info = content.value("info").toObject();
             c->height = info.value("h").toInt();
@@ -159,7 +161,7 @@ RoomMessageEvent* RoomMessageEvent::fromJson(const QJsonObject& obj)
         else if( msgtype == "m.audio" )
         {
             e->d->msgtype = MessageEventType::Audio;
-            AudioEventContent* c = new AudioEventContent;
+            AudioContent* c = new AudioContent;
             c->url = QUrl(content.value("url").toString());
             QJsonObject info = content.value("info").toObject();
             c->duration = info.value("duration").toInt();
@@ -172,7 +174,7 @@ RoomMessageEvent* RoomMessageEvent::fromJson(const QJsonObject& obj)
             qDebug() << "RoomMessageEvent: unknown msgtype: " << msgtype;
             qDebug() << obj;
             e->d->msgtype = MessageEventType::Unknown;
-            e->d->content = new MessageEventContent;
+            e->d->content = new Base;
         }
 
         if( content.contains("body") )

--- a/events/roommessageevent.cpp
+++ b/events/roommessageevent.cpp
@@ -19,7 +19,6 @@
 #include "roommessageevent.h"
 
 #include <QtCore/QJsonObject>
-#include <QtCore/QDateTime>
 #include <QtCore/QDebug>
 
 using namespace QMatrixClient;
@@ -32,7 +31,6 @@ class RoomMessageEvent::Private
         QString userId;
         MessageEventType msgtype;
         QString plainBody;
-        QDateTime hsob_ts;
         MessageEventContent::Base* content;
 };
 
@@ -66,11 +64,6 @@ QString RoomMessageEvent::plainBody() const
 QString RoomMessageEvent::body() const
 {
     return plainBody();
-}
-
-QDateTime RoomMessageEvent::hsob_ts() const
-{
-    return d->hsob_ts;
 }
 
 MessageEventContent::Base* RoomMessageEvent::content() const
@@ -189,10 +182,6 @@ RoomMessageEvent* RoomMessageEvent::fromJson(const QJsonObject& obj)
         } else {
             qDebug() << "RoomMessageEvent: body not found";
         }
-//             e->d->hsob_ts = QDateTime::fromMSecsSinceEpoch( content.value("hsoc_ts").toInt() );
-//         } else {
-//             qDebug() << "RoomMessageEvent: hsoc_ts not found";
-//         }
     }
     return e;
 }

--- a/events/roommessageevent.h
+++ b/events/roommessageevent.h
@@ -54,8 +54,6 @@ namespace QMatrixClient
              */
             QString body() const;
 
-            QDateTime hsob_ts() const;
-
             MessageEventContent::Base* content() const;
         
             static RoomMessageEvent* fromJson( const QJsonObject& obj );

--- a/events/roommessageevent.h
+++ b/events/roommessageevent.h
@@ -125,27 +125,24 @@ namespace QMatrixClient
                 ImageInfo thumbnail;
         };
 
-        // The spec structures m.video messages differently for some reason -
-        // instead of putting a thumbnail block on the top level, as with
-        // file and image, it puts it inside "info" key. So instead of
-        // using ThumbnailContent<> base, we add the thumbnail into VideoInfo explicitly.
-        class VideoContent: public FileInfo
+        class VideoInfo: public FileInfo
         {
             public:
-                VideoContent(QUrl u, const QJsonObject& infoJson);
+                VideoInfo(QUrl u, const QJsonObject& infoJson);
 
                 int duration;
                 QSize imageSize;
-                ImageInfo thumbnail;
         };
+        using VideoContent = ThumbnailedContent<VideoInfo>;
 
-        class AudioContent: public FileInfo
+        class AudioInfo: public FileInfo
         {
             public:
-                AudioContent(QUrl u, const QJsonObject& infoJson);
+                AudioInfo(QUrl u, const QJsonObject& infoJson);
 
                 int duration;
         };
+        using AudioContent = ThumbnailedContent<AudioInfo>;
     }
 }
 

--- a/events/roommessageevent.h
+++ b/events/roommessageevent.h
@@ -30,13 +30,14 @@ namespace QMatrixClient
         Text, Emote, Notice, Image, File, Location, Video, Audio, Unknown
     };
 
-    class MessageEventContent
+    namespace MessageEventContent
     {
-        public:
-            virtual ~MessageEventContent() {}
-
-            QString body;
-    };
+        class Base
+        {
+            public:
+                QString body;
+        };
+    }
 
     class RoomMessageEvent: public Event
     {
@@ -49,7 +50,7 @@ namespace QMatrixClient
             QString body() const;
             QDateTime hsob_ts() const;
 
-            MessageEventContent* content() const;
+            MessageEventContent::Base* content() const;
         
             static RoomMessageEvent* fromJson( const QJsonObject& obj );
             
@@ -58,61 +59,63 @@ namespace QMatrixClient
             Private* d;
     };
 
-    class ImageEventContent: public MessageEventContent
+    namespace MessageEventContent
     {
-        public:
-            QUrl url;
-            int height;
-            int width;
-            int size;
-            QString mimetype;
-    };
+        class ImageContent: public Base
+        {
+            public:
+                QUrl url;
+                int height;
+                int width;
+                int size;
+                QString mimetype;
+        };
 
-    class FileEventContent: public MessageEventContent
-    {
-        public:
-            QString filename;
-            QString mimetype;
-            int size;
-            QUrl url;
-    };
+        class FileContent: public Base
+        {
+            public:
+                QString filename;
+                QString mimetype;
+                int size;
+                QUrl url;
+        };
 
-    class LocationEventContent: public MessageEventContent
-    {
-        public:
-            QString geoUri;
-            int thumbnailHeight;
-            int thumbnailWidth;
-            QString thumbnailMimetype;
-            int thumbnailSize;
-            QUrl thumbnailUrl;
-    };
+        class LocationContent: public Base
+        {
+            public:
+                QString geoUri;
+                int thumbnailHeight;
+                int thumbnailWidth;
+                QString thumbnailMimetype;
+                int thumbnailSize;
+                QUrl thumbnailUrl;
+        };
 
-    class VideoEventContent: public MessageEventContent
-    {
-        public:
-            QUrl url;
-            int duration;
-            int width;
-            int height;
-            int size;
-            QString mimetype;
-            int thumbnailWidth;
-            int thumbnailHeight;
-            int thumbnailSize;
-            QString thumbnailMimetype;
-            QUrl thumbnailUrl;
-    };
+        class VideoContent: public Base
+        {
+            public:
+                QUrl url;
+                int duration;
+                int width;
+                int height;
+                int size;
+                QString mimetype;
+                int thumbnailWidth;
+                int thumbnailHeight;
+                int thumbnailSize;
+                QString thumbnailMimetype;
+                QUrl thumbnailUrl;
+        };
 
-    class AudioEventContent: public MessageEventContent
-    {
-        public:
-            QUrl url;
-            int size;
-            int duration;
-            QString mimetype;
-    };
-
+        class AudioContent: public Base
+        {
+            public:
+                QUrl url;
+                int size;
+                int duration;
+                QString mimetype;
+        };
+    }
 }
 
 #endif // QMATRIXCLIENT_ROOMMESSAGEEVENT_H

--- a/events/roommessageevent.h
+++ b/events/roommessageevent.h
@@ -32,11 +32,7 @@ namespace QMatrixClient
 
     namespace MessageEventContent
     {
-        class Base
-        {
-            public:
-                QString body;
-        };
+        class Base { };
     }
 
     class RoomMessageEvent: public Event
@@ -47,7 +43,17 @@ namespace QMatrixClient
             
             QString userId() const;
             MessageEventType msgtype() const;
+
+            QString plainBody() const;
+
+            /**
+             * Same as plainBody() for now; might change for "best-looking body"
+             * in the future. For richer contents, use content-specific data.
+             *
+             * @deprecated
+             */
             QString body() const;
+
             QDateTime hsob_ts() const;
 
             MessageEventContent::Base* content() const;

--- a/events/roommessageevent.h
+++ b/events/roommessageevent.h
@@ -20,6 +20,7 @@
 #define QMATRIXCLIENT_ROOMMESSAGEEVENT_H
 
 #include <QtCore/QUrl>
+#include <QtCore/QMimeType>
 
 #include "event.h"
 
@@ -65,6 +66,15 @@ namespace QMatrixClient
 
     namespace MessageEventContent
     {
+        class TextContent: public Base
+        {
+            public:
+                TextContent(const QJsonObject& json);
+
+                QMimeType mimeType;
+                QString body;
+        };
+
         class ImageContent: public Base
         {
             public:


### PR DESCRIPTION
I rehashed my [original attempt to refactor RoomMessageEvent and MessageEventContent family](https://github.com/Fxrh/libqmatrixclient/pull/17). The primary goals are the same: remove repetitive code that parses JSON and add HTML text messages support. An additional by-product is overall tightening of the code - in particular, messages without msgtype are no more even tried (the spec forbids those); and I chose to actually parse incoming MIME types using QMimeDatabase (it's a stock fd.o database on Linux and a Qt-bundled one on Windows).

This time it's made in several commits for easier reviewing and merging. I also abstained from renaming/moving MessageEventType. The change still breaks compatibility, as content classes have moved to a dedicated namespace. However, I only found a single place and only in Quaternion that actually names those classes, so the impact is very small. Besides, support of rich text in Quaternion needs an update to the same code in Quaternion, anyway.