### PR TITLE
A generic lookup(), and its usage in Event and RoomMessageEvent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ else ( CMAKE_VERSION VERSION_LESS "3.1" )
     target_compile_features(qmatrixclient PRIVATE cxx_auto_type)
     target_compile_features(qmatrixclient PRIVATE cxx_generalized_initializers)
     target_compile_features(qmatrixclient PRIVATE cxx_nullptr)
+    target_compile_features(qmatrixclient PRIVATE cxx_variadic_templates)
 endif ( CMAKE_VERSION VERSION_LESS "3.1" )
 
 target_link_libraries(qmatrixclient Qt5::Core Qt5::Network Qt5::Gui)

--- a/events/event.cpp
+++ b/events/event.cpp
@@ -90,27 +90,19 @@ Event* make(const QJsonObject& obj)
 
 Event* Event::fromJson(const QJsonObject& obj)
 {
-    struct Factory {
-        QString type;
-        Event* (*make)(const QJsonObject& obj);
-    };
-    const Factory evTypes[] {
-        { "m.room.message", make<RoomMessageEvent> },
-        { "m.room.name", make<RoomNameEvent> },
-        { "m.room.aliases", make<RoomAliasesEvent> },
-        { "m.room.canonical_alias", make<RoomCanonicalAliasEvent> },
-        { "m.room.member", make<RoomMemberEvent> },
-        { "m.room.topic", make<RoomTopicEvent> },
-        { "m.typing", make<TypingEvent> },
-        { "m.receipt", make<ReceiptEvent> },
-        // Insert new types before this line
-    };
-    for (auto e: evTypes)
-    {
-        if (obj["type"].toString() == e.type)
-            return e.make(obj);
-    }
-    return UnknownEvent::fromJson(obj);
+    auto delegate = lookup(obj.value("type").toString(),
+            "m.room.message", make<RoomMessageEvent>,
+            "m.room.name", make<RoomNameEvent>,
+            "m.room.aliases", make<RoomAliasesEvent>,
+            "m.room.canonical_alias", make<RoomCanonicalAliasEvent>,
+            "m.room.member", make<RoomMemberEvent>,
+            "m.room.topic", make<RoomTopicEvent>,
+            "m.typing", make<TypingEvent>,
+            "m.receipt", make<ReceiptEvent>,
+            /* Insert new event types BEFORE this line */
+            make<UnknownEvent>
+        );
+    return delegate(obj);
 }
 
 bool Event::parseJson(const QJsonObject& obj)

--- a/events/event.h
+++ b/events/event.h
@@ -83,6 +83,54 @@ namespace QMatrixClient
             }
         );
     }
+
+    /**
+     * @brief Lookup a value by a key in a varargs list
+     *
+     * The below overloaded function template takes the value of its first
+     * argument (selector) as a key and searches for it in the key-value map
+     * passed in a varargs list (every next pair of arguments forms a key-value
+     * pair). If a match is found, the respective value is returned; otherwise,
+     * the last value (fallback) is returned.
+     *
+     * All options should be of the same type or implicitly castable to the
+     * type of the first option. Note that pointers to methods of different
+     * classes are of different object types, in particular.
+     *
+     * Below is an example of usage to select a parser depending on contents of
+     * a JSON object:
+     * {@code
+     *  auto parser = lookup(obj.value["type"].toString(),
+     *                      "type1", fn1,
+     *                      "type2", fn2,
+     *                      fallbackFn);
+     *  parser(obj);
+     * }
+     *
+     * The implementation is based on tail recursion; every recursion step
+     * removes 2 arguments (match and option). There's no selector value for the
+     * fallback option (the last one); therefore, the total number of lookup()
+     * arguments should be even: selector + n key-value pairs + fallback
+     *
+     * @note Beware of calling lookup() with a <code>const char*</code> selector
+     * (the first parameter) - most likely it won't do what you expect because
+     * of shallow comparison.
+     */
+    template <typename ValueT, typename SelectorT, typename KeyT, typename... Ts>
+    ValueT lookup(SelectorT selector, KeyT key, ValueT value, Ts... remainingMapping)
+    {
+        if( selector == key )
+            return value;
+
+        // Drop the failed key-value pair and recurse with 2 arguments less.
+        return lookup(selector, remainingMapping...);
+    }
+
+    template <typename SelectorT, typename ValueT>
+    ValueT lookup(SelectorT/*unused*/, ValueT fallback)
+    {
+        return fallback;
+    }
 }
 
 #endif // QMATRIXCLIENT_EVENT_H


### PR DESCRIPTION
Another attempt to push variadic templates usage :)

Actually, this time it's really concise and generic, while applicable to two cases rather than only one. I'm even thinking to submit it for inclusion into C++20 standard :-D It's almost a textbook usage of variadic templates and tail recursion, so I hope that together with the most extensive documentation across the codebase ;) this is useful and maintainable enough. I also hope that using std::tie doesn't freak out anyone - if it does I can replace it with `RoomMessageEvent::Private::setContent()` or something.