### PR TITLE
[FEATURE] Add proper SONAME versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,8 @@ set(libqmatrixclient_SRCS
     )
 
 add_library(qmatrixclient ${libqmatrixclient_SRCS})
+set_property(TARGET qmatrixclient PROPERTY VERSION "0.0.0")
+set_property(TARGET qmatrixclient PROPERTY SOVERSION 0 )
 
 if ( CMAKE_VERSION VERSION_LESS "3.1" )
     CHECK_CXX_COMPILER_FLAG("-std=c++11" STD_FLAG_SUPPORTED)


### PR DESCRIPTION
This doesn't affect the current build process much since it build quaternion against libqmatrixclient statically, but distributions that require libraries to be built as a shared object also often require the use of symbol versioning using the SONAME, e.g openSUSE: https://en.opensuse.org/openSUSE:Shared_library_packaging_policy