### PR TITLE
Correct user sorting for room name creation

### DIFF
--- a/room.cpp
+++ b/room.cpp
@@ -497,9 +497,8 @@ QString Room::Private::roomNameFromMemberNames(const QList<User *> &userlist) co
         first_two.begin(), first_two.end(),
         [this](const User* u1, const User* u2) {
             // Filter out the "me" user so that it never hits the room name
-            if( u1 == connection->user() || u2 == connection->user() )
-                return u2 == connection->user();
-            return u1->id() < u2->id();
+            return u2 == connection->user() ||
+                    (u1 != connection->user() && u1->id() < u2->id());
         }
     );
 

--- a/room.cpp
+++ b/room.cpp
@@ -497,7 +497,9 @@ QString Room::Private::roomNameFromMemberNames(const QList<User *> &userlist) co
         first_two.begin(), first_two.end(),
         [this](const User* u1, const User* u2) {
             // Filter out the "me" user so that it never hits the room name
-            return u1 != connection->user() && u1->id() < u2->id();
+            if( u1 == connection->user() || u2 == connection->user() )
+                return u2 == connection->user();
+            return u1->id() < u2->id();
         }
     );
 


### PR DESCRIPTION
In the previous version, it was possible that u1 >= u2 and u2 >= u1:
Assume u1 == me, u1->id() < u2->id()
Then u1 >= u2, as u1 == me (i.e. it returns false)
but also u2 >= u1, as u2->id() > u1->id() (returns false again)
    
For me, this had the effect of having three rooms called fxrh.