### PR TITLE
Connection: Don't return SyncJob* from sync()

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -163,10 +163,10 @@ void Connection::logout()
     job->start();
 }
 
-SyncJob* Connection::sync(int timeout)
+void Connection::sync(int timeout)
 {
     if (d->syncJob)
-        return d->syncJob;
+        return;
 
     const QString filter = "{\"room\": { \"timeline\": { \"limit\": 100 } } }";
     auto job = d->startSyncJob(filter, timeout);
@@ -187,7 +187,6 @@ SyncJob* Connection::sync(int timeout)
         else
             emit connectionError(job->errorString());
     });
-    return job;
 }
 
 SyncJob* Connection::Private::startSyncJob(const QString& filter, int timeout)

--- a/connection.h
+++ b/connection.h
@@ -52,7 +52,7 @@ namespace QMatrixClient
             Q_INVOKABLE virtual void disconnectFromServer();
             Q_INVOKABLE virtual void logout();
 
-            Q_INVOKABLE virtual SyncJob* sync(int timeout=-1);
+            Q_INVOKABLE virtual void sync(int timeout=-1);
             Q_INVOKABLE virtual void postMessage( Room* room, QString type, QString message );
             Q_INVOKABLE virtual PostReceiptJob* postReceipt( Room* room, Event* event );
             Q_INVOKABLE virtual void joinRoom( QString roomAlias );


### PR DESCRIPTION
Given that Connection handles all the output from SyncJob already, there's no use in having the pointer. In fact, it's not used in Quaternion, and Tensor, to the contrary, has a problem _because_ this pointer is grabbed by the QML engine that mistakenly tries to handle its lifecycle. Better get rid of it.