### PR TITLE
Fix messages ordering

### DIFF
--- a/events/event.h
+++ b/events/event.h
@@ -35,7 +35,7 @@ namespace QMatrixClient
         RoomMessage, RoomName, RoomAliases, RoomCanonicalAlias,
         RoomMember, RoomTopic, Typing, Receipt, Unknown
     };
-    
+
     class Event
     {
         public:
@@ -61,28 +61,7 @@ namespace QMatrixClient
     };
     using Events = QVector<Event*>;
 
-    Events eventsFromJson(const QJsonArray& contents);
-
-    /**
-     * Finds a place in the timeline where a new event/message could be inserted.
-     * @return an iterator to an item with the earliest timestamp after
-     * the one of 'item'; or timeline.end(), if all events are earlier
-     */
-    template <class ItemT, class ContT>
-    typename ContT::iterator
-    findInsertionPos(ContT & timeline, const ItemT *item)
-    {
-        return std::lower_bound (timeline.begin(), timeline.end(), item,
-            [](const typename ContT::value_type a, const ItemT * b) {
-                // FIXME: We should not order the message list by origin timestamp.
-                // Rather, an order of receiving should be used (which actually
-                // poses a question on whether this method is needed at all -
-                // or we'd just prepend and append, depending on whether we
-                // received something from /sync or from /messages.
-                return a->timestamp() < b->timestamp();
-            }
-        );
-    }
+    Events eventsFromJson(const QJsonArray& json);
 
     /**
      * @brief Lookup a value by a key in a varargs list

--- a/room.cpp
+++ b/room.cpp
@@ -409,10 +409,9 @@ void Room::addHistoricalMessageEvents(const Events& events)
 
 void Room::doAddHistoricalMessageEvents(const Events& events)
 {
-    // Preserver the order of messages when inserting the block in the
-    // beginning of the container.
-    std::reverse_copy(events.begin(), events.end(),
-                      std::front_inserter(d->messageEvents));
+    // Historical messages arrive in newest-to-oldest order
+    d->messageEvents.reserve(d->messageEvents.size() + events.size());
+    std::copy(events.begin(), events.end(), std::front_inserter(d->messageEvents));
 }
 
 void Room::processStateEvents(const Events& events)

--- a/room.cpp
+++ b/room.cpp
@@ -46,7 +46,7 @@ class Room::Private
     public:
         /** Map of user names to users. User names potentially duplicate, hence a multi-hashmap. */
         typedef QMultiHash<QString, User*> members_map_t;
-        
+
         Private(Connection* c, const QString& id_)
             : q(nullptr), connection(c), id(id_), joinState(JoinState::Join)
             , roomMessagesJob(nullptr)
@@ -76,7 +76,7 @@ class Room::Private
         QHash<User*, QString> lastReadEvent;
         QString prevBatch;
         RoomMessagesJob* roomMessagesJob;
-        
+
         // Convenience methods to work with the membersMap and usersLeft.
         // addMember() and removeMember() emit respective Room:: signals
         // after a succesful operation.
@@ -335,18 +335,12 @@ void Room::updateData(const SyncRoomData& data)
         d->prevBatch = data.timelinePrevBatch;
     setJoinState(data.joinState);
 
-    for( Event* stateEvent: data.state )
-    {
-        processStateEvent(stateEvent);
-    }
+    processStateEvents(data.state);
 
     if (!data.timeline.empty())
     {
-        for( Event* e: data.timeline )
-        {
-            // State changes can arrive in a timeline event; so check those.
-            processStateEvent(e);
-        }
+        // State changes can arrive in a timeline event; so check those.
+        processStateEvents(data.timeline);
         addNewMessageEvents(data.timeline);
     }
 
@@ -421,56 +415,53 @@ void Room::doAddHistoricalMessageEvents(const Events& events)
                       std::front_inserter(d->messageEvents));
 }
 
-void Room::processStateEvent(Event* event)
+void Room::processStateEvents(const Events& events)
 {
-    if( event->type() == EventType::RoomName )
+    for (auto event: events)
     {
-        if (RoomNameEvent* nameEvent = static_cast<RoomNameEvent*>(event))
+        if( event->type() == EventType::RoomName )
         {
+            RoomNameEvent* nameEvent = static_cast<RoomNameEvent*>(event);
             d->name = nameEvent->name();
             qDebug() << "room name:" << d->name;
             d->updateDisplayname();
             emit namesChanged(this);
-        } else
-        {
-            qDebug() <<
-                "!!! event type is RoomName but the event is not RoomNameEvent";
         }
-    }
-    if( event->type() == EventType::RoomAliases )
-    {
-        RoomAliasesEvent* aliasesEvent = static_cast<RoomAliasesEvent*>(event);
-        d->aliases = aliasesEvent->aliases();
-        qDebug() << "room aliases:" << d->aliases;
-        // No displayname update - aliases are not used to render a displayname
-        emit namesChanged(this);
-    }
-    if( event->type() == EventType::RoomCanonicalAlias )
-    {
-        RoomCanonicalAliasEvent* aliasEvent = static_cast<RoomCanonicalAliasEvent*>(event);
-        d->canonicalAlias = aliasEvent->alias();
-        qDebug() << "room canonical alias:" << d->canonicalAlias;
-        d->updateDisplayname();
-        emit namesChanged(this);
-    }
-    if( event->type() == EventType::RoomTopic )
-    {
-        RoomTopicEvent* topicEvent = static_cast<RoomTopicEvent*>(event);
-        d->topic = topicEvent->topic();
-        emit topicChanged();
-    }
-    if( event->type() == EventType::RoomMember )
-    {
-        RoomMemberEvent* memberEvent = static_cast<RoomMemberEvent*>(event);
-        User* u = d->connection->user(memberEvent->userId());
-        u->processEvent(event);
-        if( memberEvent->membership() == MembershipType::Join )
+        if( event->type() == EventType::RoomAliases )
         {
-            d->addMember(u);
+            RoomAliasesEvent* aliasesEvent = static_cast<RoomAliasesEvent*>(event);
+            d->aliases = aliasesEvent->aliases();
+            qDebug() << "room aliases:" << d->aliases;
+            // No displayname update - aliases are not used to render a displayname
+            emit namesChanged(this);
         }
-        else if( memberEvent->membership() == MembershipType::Leave )
+        if( event->type() == EventType::RoomCanonicalAlias )
         {
-            d->removeMember(u);
+            RoomCanonicalAliasEvent* aliasEvent = static_cast<RoomCanonicalAliasEvent*>(event);
+            d->canonicalAlias = aliasEvent->alias();
+            qDebug() << "room canonical alias:" << d->canonicalAlias;
+            d->updateDisplayname();
+            emit namesChanged(this);
+        }
+        if( event->type() == EventType::RoomTopic )
+        {
+            RoomTopicEvent* topicEvent = static_cast<RoomTopicEvent*>(event);
+            d->topic = topicEvent->topic();
+            emit topicChanged();
+        }
+        if( event->type() == EventType::RoomMember )
+        {
+            RoomMemberEvent* memberEvent = static_cast<RoomMemberEvent*>(event);
+            User* u = d->connection->user(memberEvent->userId());
+            u->processEvent(event);
+            if( memberEvent->membership() == MembershipType::Join )
+            {
+                d->addMember(u);
+            }
+            else if( memberEvent->membership() == MembershipType::Leave )
+            {
+                d->removeMember(u);
+            }
         }
     }
 }

--- a/room.h
+++ b/room.h
@@ -82,13 +82,17 @@ namespace QMatrixClient
             void userRenamed(User* user, QString oldName);
 
         signals:
-            void newMessage(Event* event);
+            void aboutToAddHistoricalMessages(const Events& events);
+            void aboutToAddNewMessages(const Events& events);
+            void addedMessages();
+
             /**
-             * Triggered when the room name, canonical alias or other aliases
-             * change. Not triggered when displayname changes.
+             * @brief The room name, the canonical alias or other aliases changed
+             *
+             * Not triggered when displayname changes.
              */
             void namesChanged(Room* room);
-            /** Triggered only for changes in the room displayname. */
+            /** @brief The room displayname changed */
             void displaynameChanged(Room* room);
             void topicChanged();
             void userAdded(User* user);
@@ -101,13 +105,17 @@ namespace QMatrixClient
 
         protected:
             Connection* connection() const;
-            virtual void processMessageEvent(Event* event);
+            virtual void doAddNewMessageEvents(const Events& events);
+            virtual void doAddHistoricalMessageEvents(const Events& events);
             virtual void processStateEvent(Event* event);
             virtual void processEphemeralEvent(Event* event);
 
         private:
             class Private;
             Private* d;
+
+            void addNewMessageEvents(const Events& events);
+            void addHistoricalMessageEvents(const Events& events);
     };
 }
 

--- a/room.h
+++ b/room.h
@@ -107,7 +107,7 @@ namespace QMatrixClient
             Connection* connection() const;
             virtual void doAddNewMessageEvents(const Events& events);
             virtual void doAddHistoricalMessageEvents(const Events& events);
-            virtual void processStateEvent(Event* event);
+            virtual void processStateEvents(const Events& events);
             virtual void processEphemeralEvent(Event* event);
 
         private:


### PR DESCRIPTION
This switches from ordering messages by origin_server_ts to relying on the order messages arrive in from the server. Such change requires to change the way `Room` notifies clients about messages: instead of one signal per message it now emits two signals for the whole block of messages (see the details in the first commit message). On the other hand, we have to distinguish between "new" and "historical" messages now, as these get added to different ends of the room timeline and processing them in clients is different, too. Therefore two different functions to deal with arrived messages, and 3 different kinds of signals (details are also in the commit message).

The second commit is relatively uncoupled - it just groups state events in the same way timeline events are grouped now.