### PR TITLE
Push sender from RoomTopicEvent to Event

### DIFF
--- a/events/event.cpp
+++ b/events/event.cpp
@@ -43,6 +43,7 @@ class Event::Private
         QString id;
         QDateTime timestamp;
         QString roomId;
+        QString senderId;
         QString originalJson;
 };
 
@@ -75,6 +76,11 @@ QDateTime Event::timestamp() const
 QString Event::roomId() const
 {
     return d->roomId;
+}
+
+QString Event::senderId() const
+{
+    return d->senderId;
 }
 
 QString Event::originalJson() const
@@ -131,10 +137,8 @@ bool Event::parseJson(const QJsonObject& obj)
             qDebug() << formatJson << obj;
         }
     }
-    if( obj.contains("room_id") )
-    {
-        d->roomId = obj.value("room_id").toString();
-    }
+    d->roomId = obj.value("room_id").toString();
+    d->senderId = obj.value("sender").toString();
     return correct;
 }
 

--- a/events/event.h
+++ b/events/event.h
@@ -47,6 +47,7 @@ namespace QMatrixClient
             QString id() const;
             QDateTime timestamp() const;
             QString roomId() const;
+            QString senderId() const;
             // only for debug purposes!
             QString originalJson() const;
 

--- a/events/roomtopicevent.cpp
+++ b/events/roomtopicevent.cpp
@@ -24,7 +24,6 @@ class RoomTopicEvent::Private
 {
     public:
         QString topic;
-        QString senderId;
 };
 
 RoomTopicEvent::RoomTopicEvent()
@@ -38,11 +37,6 @@ RoomTopicEvent::~RoomTopicEvent()
     delete d;
 }
 
-QString RoomTopicEvent::senderId() const
-{
-    return d->senderId;
-}
-
 QString RoomTopicEvent::topic() const
 {
     return d->topic;
@@ -53,6 +47,5 @@ RoomTopicEvent* RoomTopicEvent::fromJson(const QJsonObject& obj)
     auto e = new RoomTopicEvent();
     e->parseJson(obj);
     e->d->topic = obj.value("content").toObject().value("topic").toString();
-    e->d->senderId = obj["sender"].toString();
     return e;
 }

--- a/events/roomtopicevent.h
+++ b/events/roomtopicevent.h
@@ -31,7 +31,6 @@ namespace QMatrixClient
             RoomTopicEvent();
             virtual ~RoomTopicEvent();
 
-            QString senderId() const;
             QString topic() const;
 
             static RoomTopicEvent* fromJson(const QJsonObject& obj);


### PR DESCRIPTION
Because it's supposed to exist in (at least) all events from sync (see [CS spec](https://matrix.org/speculator/spec/HEAD/client_server/unstable.html#get-matrix-client-unstable-sync), `Event` structure definition).