### PR TITLE
MediaThumbnailJob: Use QSize instead of two separate int's for size

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -27,7 +27,6 @@
 #include "jobs/postreceiptjob.h"
 #include "jobs/joinroomjob.h"
 #include "jobs/leaveroomjob.h"
-#include "jobs/roommembersjob.h"
 #include "jobs/roommessagesjob.h"
 #include "jobs/syncjob.h"
 #include "jobs/mediathumbnailjob.h"
@@ -234,11 +233,16 @@ RoomMessagesJob* Connection::getMessages(Room* room, QString from)
     return job;
 }
 
-MediaThumbnailJob* Connection::getThumbnail(QUrl url, int requestedWidth, int requestedHeight)
+MediaThumbnailJob* Connection::getThumbnail(QUrl url, QSize requestedSize)
 {
-    MediaThumbnailJob* job = new MediaThumbnailJob(d->data, url, requestedWidth, requestedHeight);
+    MediaThumbnailJob* job = new MediaThumbnailJob(d->data, url, requestedSize);
     job->start();
     return job;
+}
+
+MediaThumbnailJob* Connection::getThumbnail(QUrl url, int requestedWidth, int requestedHeight)
+{
+    return getThumbnail(url, QSize(requestedWidth, requestedHeight));
 }
 
 QUrl Connection::homeserver() const

--- a/connection.h
+++ b/connection.h
@@ -58,7 +58,8 @@ namespace QMatrixClient
             Q_INVOKABLE virtual void joinRoom( QString roomAlias );
             Q_INVOKABLE virtual void leaveRoom( Room* room );
             Q_INVOKABLE virtual RoomMessagesJob* getMessages( Room* room, QString from );
-            virtual MediaThumbnailJob* getThumbnail( QUrl url, int requestedWidth, int requestedHeight );
+            virtual MediaThumbnailJob* getThumbnail( QUrl url, QSize requestedSize );
+            MediaThumbnailJob* getThumbnail( QUrl url, int requestedWidth, int requestedHeight );
 
             Q_INVOKABLE QUrl homeserver() const;
             Q_INVOKABLE User* user(QString userId);

--- a/jobs/mediathumbnailjob.cpp
+++ b/jobs/mediathumbnailjob.cpp
@@ -27,19 +27,17 @@ class MediaThumbnailJob::Private
     public:
         QUrl url;
         QPixmap thumbnail;
-        int requestedHeight;
-        int requestedWidth;
+        QSize requestedSize;
         ThumbnailType thumbnailType;
 };
 
-MediaThumbnailJob::MediaThumbnailJob(ConnectionData* data, QUrl url, int requestedWidth, int requestedHeight,
+MediaThumbnailJob::MediaThumbnailJob(ConnectionData* data, QUrl url, QSize requestedSize,
                                      ThumbnailType thumbnailType)
     : BaseJob(data, JobHttpType::GetJob, "MediaThumbnailJob")
     , d(new Private)
 {
     d->url = url;
-    d->requestedHeight = requestedHeight;
-    d->requestedWidth = requestedWidth;
+    d->requestedSize = requestedSize;
     d->thumbnailType = thumbnailType;
 }
 
@@ -61,8 +59,8 @@ QString MediaThumbnailJob::apiPath() const
 QUrlQuery MediaThumbnailJob::query() const
 {
     QUrlQuery query;
-    query.addQueryItem("width", QString::number(d->requestedWidth));
-    query.addQueryItem("height", QString::number(d->requestedHeight));
+    query.addQueryItem("width", QString::number(d->requestedSize.width()));
+    query.addQueryItem("height", QString::number(d->requestedSize.height()));
     if( d->thumbnailType == ThumbnailType::Scale )
         query.addQueryItem("method", "scale");
     else

--- a/jobs/mediathumbnailjob.h
+++ b/jobs/mediathumbnailjob.h
@@ -30,7 +30,7 @@ namespace QMatrixClient
     class MediaThumbnailJob: public BaseJob
     {
         public:
-            MediaThumbnailJob(ConnectionData* data, QUrl url, int requestedWidth, int requestedHeight,
+            MediaThumbnailJob(ConnectionData* data, QUrl url, QSize requestedSize,
                               ThumbnailType thumbnailType=ThumbnailType::Scale);
             virtual ~MediaThumbnailJob();
 


### PR DESCRIPTION
This is a rather straightforward replacement of dealing with pairs of `int`'s to a single `QSize` structure. The previous `Connection::getThumbnail()` is also kept, for compatibility.

I also took liberty and used `QVector` instead of `QHash` to store differently scaled pixmaps in `User::Private`: given that we're going to have a very limited number of them for each user, the overhead on the hashmap structure will be greater than benefits from it.