### PR TITLE
BaseJob: Use saved parameters instead of overriding apiPath(), query() and data() in each job class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ set(libqmatrixclient_SRCS
    jobs/postreceiptjob.cpp
    jobs/joinroomjob.cpp
    jobs/leaveroomjob.cpp
-   jobs/roommembersjob.cpp
    jobs/roommessagesjob.cpp
    jobs/syncjob.cpp
    jobs/mediathumbnailjob.cpp

--- a/connection.cpp
+++ b/connection.cpp
@@ -189,7 +189,7 @@ void Connection::sync(int timeout)
 
 SyncJob* Connection::Private::startSyncJob(const QString& filter, int timeout)
 {
-    syncJob = new SyncJob(data, filter, timeout, data->lastEvent());
+    syncJob = new SyncJob(data, data->lastEvent(), filter, timeout);
     syncJob->start();
     return syncJob;
 

--- a/connection.cpp
+++ b/connection.cpp
@@ -189,9 +189,7 @@ void Connection::sync(int timeout)
 
 SyncJob* Connection::Private::startSyncJob(const QString& filter, int timeout)
 {
-    syncJob = new SyncJob(data, data->lastEvent());
-    syncJob->setFilter(filter);
-    syncJob->setTimeout(timeout);
+    syncJob = new SyncJob(data, filter, timeout, data->lastEvent());
     syncJob->start();
     return syncJob;
 

--- a/jobs/checkauthmethods.cpp
+++ b/jobs/checkauthmethods.cpp
@@ -37,7 +37,8 @@ class CheckAuthMethods::Private
 };
 
 CheckAuthMethods::CheckAuthMethods(ConnectionData* connection)
-    : BaseJob(connection, JobHttpType::GetJob, "CheckAuthMethods", false)
+    : BaseJob(connection, JobHttpType::GetJob, "CheckAuthMethods",
+              "_matrix/client/r0/login", Query(), Data(), false)
     , d(new Private)
 {
 }
@@ -50,11 +51,6 @@ CheckAuthMethods::~CheckAuthMethods()
 QString CheckAuthMethods::session()
 {
     return d->session;
-}
-
-QString CheckAuthMethods::apiPath() const
-{
-    return "_matrix/client/r0/login";
 }
 
 BaseJob::Status CheckAuthMethods::parseJson(const QJsonDocument& data)

--- a/jobs/checkauthmethods.h
+++ b/jobs/checkauthmethods.h
@@ -34,7 +34,6 @@ namespace QMatrixClient
             QString session();
             
         protected:
-            QString apiPath() const override;
             Status parseJson(const QJsonDocument& data) override;
             
         private:

--- a/jobs/joinroomjob.cpp
+++ b/jobs/joinroomjob.cpp
@@ -29,14 +29,13 @@ class JoinRoomJob::Private
 {
     public:
         QString roomId;
-        QString roomAlias;
 };
 
 JoinRoomJob::JoinRoomJob(ConnectionData* data, QString roomAlias)
-    : BaseJob(data, JobHttpType::PostJob, "JoinRoomJob")
+    : BaseJob(data, JobHttpType::PostJob, "JoinRoomJob",
+              QString("_matrix/client/r0/join/%1").arg(roomAlias))
     , d(new Private)
 {
-    d->roomAlias = roomAlias;
 }
 
 JoinRoomJob::~JoinRoomJob()
@@ -47,11 +46,6 @@ JoinRoomJob::~JoinRoomJob()
 QString JoinRoomJob::roomId()
 {
     return d->roomId;
-}
-
-QString JoinRoomJob::apiPath() const
-{
-    return QString("_matrix/client/r0/join/%1").arg(d->roomAlias);
 }
 
 BaseJob::Status JoinRoomJob::parseJson(const QJsonDocument& data)

--- a/jobs/joinroomjob.h
+++ b/jobs/joinroomjob.h
@@ -34,7 +34,6 @@ namespace QMatrixClient
             QString roomId();
 
             protected:
-                QString apiPath() const override;
                 Status parseJson(const QJsonDocument& data) override;
 
             private:

--- a/jobs/leaveroomjob.cpp
+++ b/jobs/leaveroomjob.cpp
@@ -18,33 +18,14 @@
 
 #include "leaveroomjob.h"
 
-#include <QtNetwork/QNetworkReply>
-
 #include "../room.h"
-#include "../connectiondata.h"
 
 using namespace QMatrixClient;
 
-class LeaveRoomJob::Private
-{
-    public:
-        Private(Room* r) : room(r) {}
-
-        Room* room;
-};
-
 LeaveRoomJob::LeaveRoomJob(ConnectionData* data, Room* room)
-    : BaseJob(data, JobHttpType::PostJob, "LeaveRoomJob")
-    , d(new Private(room))
-{
-}
+    : BaseJob(data, JobHttpType::PostJob, "LeaveRoomJob",
+              QString("_matrix/client/r0/rooms/%1/leave").arg(room->id()))
+{ }
 
 LeaveRoomJob::~LeaveRoomJob()
-{
-    delete d;
-}
-
-QString LeaveRoomJob::apiPath() const
-{
-    return QString("_matrix/client/r0/rooms/%1/leave").arg(d->room->id());
-}
+{ }

--- a/jobs/leaveroomjob.h
+++ b/jobs/leaveroomjob.h
@@ -31,13 +31,6 @@ namespace QMatrixClient
         public:
             LeaveRoomJob(ConnectionData* data, Room* room);
             virtual ~LeaveRoomJob();
-
-        protected:
-            QString apiPath() const override;
-
-        private:
-            class Private;
-            Private* d;
     };
 }
 

--- a/jobs/logoutjob.cpp
+++ b/jobs/logoutjob.cpp
@@ -21,15 +21,10 @@
 using namespace QMatrixClient;
 
 LogoutJob::LogoutJob(ConnectionData* connection)
-    : BaseJob(connection, JobHttpType::PostJob, "LogoutJob")
+    : BaseJob(connection, JobHttpType::PostJob, "LogoutJob", "/_matrix/client/r0/logout")
 {
 }
 
 LogoutJob::~LogoutJob()
 {
-}
-
-QString LogoutJob::apiPath() const
-{
-    return "/_matrix/client/r0/logout";
 }

--- a/jobs/logoutjob.h
+++ b/jobs/logoutjob.h
@@ -27,8 +27,5 @@ namespace QMatrixClient
         public:
             LogoutJob(ConnectionData* connection);
             virtual ~LogoutJob();
-
-        protected:
-            QString apiPath() const override;
     };
 }

--- a/jobs/mediathumbnailjob.cpp
+++ b/jobs/mediathumbnailjob.cpp
@@ -25,21 +25,21 @@ using namespace QMatrixClient;
 class MediaThumbnailJob::Private
 {
     public:
-        QUrl url;
         QPixmap thumbnail;
-        QSize requestedSize;
-        ThumbnailType thumbnailType;
 };
 
 MediaThumbnailJob::MediaThumbnailJob(ConnectionData* data, QUrl url, QSize requestedSize,
                                      ThumbnailType thumbnailType)
-    : BaseJob(data, JobHttpType::GetJob, "MediaThumbnailJob")
+    : BaseJob(data, JobHttpType::GetJob, "MediaThumbnailJob",
+              QString("/_matrix/media/v1/thumbnail/%1%2").arg(url.host(), url.path()),
+              Query(
+                { { "width", QString::number(requestedSize.width()) }
+                , { "height", QString::number(requestedSize.height()) }
+                , { "method",
+                    thumbnailType == ThumbnailType::Scale ? "scale" : "crop" }
+                }))
     , d(new Private)
-{
-    d->url = url;
-    d->requestedSize = requestedSize;
-    d->thumbnailType = thumbnailType;
-}
+{ }
 
 MediaThumbnailJob::~MediaThumbnailJob()
 {
@@ -49,23 +49,6 @@ MediaThumbnailJob::~MediaThumbnailJob()
 QPixmap MediaThumbnailJob::thumbnail()
 {
     return d->thumbnail;
-}
-
-QString MediaThumbnailJob::apiPath() const
-{
-    return QString("/_matrix/media/v1/thumbnail/%1%2").arg(d->url.host()).arg(d->url.path());
-}
-
-QUrlQuery MediaThumbnailJob::query() const
-{
-    QUrlQuery query;
-    query.addQueryItem("width", QString::number(d->requestedSize.width()));
-    query.addQueryItem("height", QString::number(d->requestedSize.height()));
-    if( d->thumbnailType == ThumbnailType::Scale )
-        query.addQueryItem("method", "scale");
-    else
-        query.addQueryItem("method", "crop");
-    return query;
 }
 
 BaseJob::Status MediaThumbnailJob::parseReply(QByteArray data)

--- a/jobs/mediathumbnailjob.h
+++ b/jobs/mediathumbnailjob.h
@@ -37,9 +37,6 @@ namespace QMatrixClient
             QPixmap thumbnail();
 
         protected:
-            QString apiPath() const override;
-            QUrlQuery query() const override;
-
             Status parseReply(QByteArray data) override;
 
         private:

--- a/jobs/passwordlogin.cpp
+++ b/jobs/passwordlogin.cpp
@@ -29,21 +29,24 @@ using namespace QMatrixClient;
 class PasswordLogin::Private
 {
     public:
-        Private() {}
-
-        QString user;
-        QString password;
         QString returned_id;
         QString returned_server;
         QString returned_token;
 };
 
 PasswordLogin::PasswordLogin(ConnectionData* connection, QString user, QString password)
-    : BaseJob(connection, JobHttpType::PostJob, "PasswordLogin", false)
+    : BaseJob(connection, JobHttpType::PostJob, "PasswordLogin"
+            , "_matrix/client/r0/login"
+            , Query()
+            , Data(
+                { { "type", "m.login.password" }
+                , { "user", user }
+                , { "password", password }
+                })
+            , false
+            )
     , d(new Private)
 {
-    d->user = user;
-    d->password = password;
 }
 
 PasswordLogin::~PasswordLogin()
@@ -64,20 +67,6 @@ QString PasswordLogin::id()
 QString PasswordLogin::server()
 {
     return d->returned_server;
-}
-
-QString PasswordLogin::apiPath() const
-{
-    return "_matrix/client/r0/login";
-}
-
-QJsonObject PasswordLogin::data() const
-{
-    QJsonObject json;
-    json.insert("type", QLatin1String("m.login.password"));
-    json.insert("user", d->user);
-    json.insert("password", d->password);
-    return json;
 }
 
 BaseJob::Status PasswordLogin::parseJson(const QJsonDocument& data)

--- a/jobs/passwordlogin.h
+++ b/jobs/passwordlogin.h
@@ -36,8 +36,6 @@ namespace QMatrixClient
             QString server();
 
         protected:
-            QString apiPath() const override;
-            QJsonObject data() const override;
             Status parseJson(const QJsonDocument& data) override;
 
         private:

--- a/jobs/postmessagejob.cpp
+++ b/jobs/postmessagejob.cpp
@@ -29,36 +29,20 @@ class PostMessageJob::Private
     public:
         Private() {}
 
-        QString type;
-        QString message;
-        Room* room;
+        QString eventId; // unused yet
 };
 
 PostMessageJob::PostMessageJob(ConnectionData* connection, Room* room, QString type, QString message)
-    : BaseJob(connection, JobHttpType::PostJob, "PostMessageJob")
+    : BaseJob(connection, JobHttpType::PostJob, "PostMessageJob",
+              QString("_matrix/client/r0/rooms/%1/send/m.room.message").arg(room->id()),
+              Query(),
+              Data({ { "msgtype", type }, { "body", message } }))
     , d(new Private)
-{
-    d->type = type;
-    d->message = message;
-    d->room = room;
-}
+{ }
 
 PostMessageJob::~PostMessageJob()
 {
     delete d;
-}
-
-QString PostMessageJob::apiPath() const
-{
-    return QString("_matrix/client/r0/rooms/%1/send/m.room.message").arg(d->room->id());
-}
-
-QJsonObject PostMessageJob::data() const
-{
-    QJsonObject json;
-    json.insert("msgtype", d->type);
-    json.insert("body", d->message);
-    return json;
 }
 
 BaseJob::Status PostMessageJob::parseJson(const QJsonDocument& data)

--- a/jobs/postmessagejob.h
+++ b/jobs/postmessagejob.h
@@ -33,8 +33,6 @@ namespace QMatrixClient
             //bool success();
 
         protected:
-            QString apiPath() const override;
-            QJsonObject data() const override;
             Status parseJson(const QJsonDocument& data) override;
 
         private:

--- a/jobs/postreceiptjob.cpp
+++ b/jobs/postreceiptjob.cpp
@@ -34,19 +34,13 @@ class PostReceiptJob::Private
 };
 
 PostReceiptJob::PostReceiptJob(ConnectionData* connection, QString roomId, QString eventId)
-    : BaseJob(connection, JobHttpType::PostJob, "PostReceiptJob")
+    : BaseJob(connection, JobHttpType::PostJob, "PostReceiptJob",
+              QString("/_matrix/client/r0/rooms/%1/receipt/m.read/%2").arg(roomId, eventId))
     , d(new Private)
 {
-    d->roomId = roomId;
-    d->eventId = eventId;
 }
 
 PostReceiptJob::~PostReceiptJob()
 {
     delete d;
-}
-
-QString PostReceiptJob::apiPath() const
-{
-    return QString("/_matrix/client/r0/rooms/%1/receipt/m.read/%2").arg(d->roomId).arg(d->eventId);
 }

--- a/jobs/postreceiptjob.h
+++ b/jobs/postreceiptjob.h
@@ -30,9 +30,6 @@ namespace QMatrixClient
             PostReceiptJob(ConnectionData* connection, QString roomId, QString eventId);
             virtual ~PostReceiptJob();
 
-        protected:
-            QString apiPath() const override;
-
         private:
             class Private;
             Private* d;

--- a/jobs/roommessagesjob.h
+++ b/jobs/roommessagesjob.h
@@ -32,15 +32,14 @@ namespace QMatrixClient
     class RoomMessagesJob: public BaseJob
     {
         public:
-            RoomMessagesJob(ConnectionData* data, Room* room, QString from, FetchDirectory dir = FetchDirectory::Backwards, int limit=10);
+            RoomMessagesJob(ConnectionData* data, Room* room, QString from,
+                            FetchDirectory dir = FetchDirectory::Backwards, int limit=10);
             virtual ~RoomMessagesJob();
 
             Events events();
             QString end();
 
         protected:
-            QString apiPath() const override;
-            QUrlQuery query() const override;
             Status parseJson(const QJsonDocument& data) override;
 
         private:

--- a/jobs/syncjob.cpp
+++ b/jobs/syncjob.cpp
@@ -38,8 +38,8 @@ class SyncJob::Private
 
 static size_t jobId = 0;
 
-SyncJob::SyncJob(ConnectionData* connection, QString filter, int timeout,
-                 QString since, QString presence)
+SyncJob::SyncJob(ConnectionData* connection,
+                 QString since, QString filter, int timeout, QString presence)
     : BaseJob(connection, JobHttpType::GetJob, QString("SyncJob-%1").arg(++jobId),
               "_matrix/client/r0/sync")
     , d(new Private)

--- a/jobs/syncjob.h
+++ b/jobs/syncjob.h
@@ -99,8 +99,8 @@ namespace QMatrixClient
     class SyncJob: public BaseJob
     {
         public:
-            SyncJob(ConnectionData* connection, QString filter, int timeout,
-                    QString since = {}, QString presence = {});
+            SyncJob(ConnectionData* connection, QString since = {}, QString filter = {},
+                    int timeout = -1, QString presence = {});
             virtual ~SyncJob();
             
             SyncData& roomData();

--- a/jobs/syncjob.h
+++ b/jobs/syncjob.h
@@ -99,20 +99,14 @@ namespace QMatrixClient
     class SyncJob: public BaseJob
     {
         public:
-            SyncJob(ConnectionData* connection, QString since=QString());
+            SyncJob(ConnectionData* connection, QString filter, int timeout,
+                    QString since = {}, QString presence = {});
             virtual ~SyncJob();
             
-            void setFilter(QString filter);
-            void setFullState(bool full);
-            void setPresence(QString presence);
-            void setTimeout(int timeout);
-
             SyncData& roomData();
             QString nextBatch() const;
 
         protected:
-            QString apiPath() const override;
-            QUrlQuery query() const override;
             Status parseJson(const QJsonDocument& data) override;
 
         private:


### PR DESCRIPTION
This is a rather wide-reaching change; it doesn't affect clients, and is rather easy to understand though. The rationale for it is that virtual functions normally should describe polymorphism in behaviour, not in data. Given that the passed parameters end up in a type-agnostic `QNetworkRequest`, there's not much use in have those chunks of data separately. So what I've done is simply saving the already type-erased components of `QNetworkRequest` right at the moment of `BaseJob` construction. This saves numerous descendants of `BaseJob` from having to override `apiPath()`, `query()` and/or `data()`, instead taking them to do all necessary conversions in their constructors. The simpler cases (`LogoutJob` for instance) become very trivial then; and the more complicated cases (see `SyncJob`) still have all request building complexity in a single method (the constructor, that is). And we're saving in runtime on virtual invocations, too.