### PR TITLE
Unread messages implementation in the library

### DIFF
--- a/room.cpp
+++ b/room.cpp
@@ -28,7 +28,6 @@
 #include "connection.h"
 #include "state.h"
 #include "user.h"
-#include "events/event.h"
 #include "events/roommessageevent.h"
 #include "events/roomnameevent.h"
 #include "events/roomaliasesevent.h"
@@ -676,4 +675,20 @@ void Room::Private::updateDisplayname()
     displayname = calculateDisplayname();
     if (old_name != displayname)
         emit q->displaynameChanged(q);
+}
+
+MemberSorter Room::memberSorter() const
+{
+    return MemberSorter(this);
+}
+
+bool MemberSorter::operator()(User *u1, User *u2) const
+{
+    auto n1 = room->roomMembername(u1);
+    auto n2 = room->roomMembername(u2);
+    if (n1[0] == '@')
+        n1.remove(0, 1);
+    if (n2[0] == '@')
+        n2.remove(0, 1);
+    return n1 < n2;
 }

--- a/room.cpp
+++ b/room.cpp
@@ -511,7 +511,7 @@ void Room::doAddNewMessageEvents(const Events& events)
     // automatically promote any further. Others will need explicit read receipts
     // from the server (or, for the local user, markMessagesAsRead() invocation)
     // to promote their read markers over the new message events.
-    User* firstWriter = d->member(events.front()->senderId());
+    User* firstWriter = connection()->user(events.front()->senderId());
     bool canAutoPromote = d->messageEvents.empty() ||
             lastReadEvent(firstWriter) == d->messageEvents.back()->id();
     Event* firstWriterSeriesEnd = canAutoPromote ? events.front() : nullptr;

--- a/room.cpp
+++ b/room.cpp
@@ -200,10 +200,12 @@ bool Room::promoteReadMarker(QString newLastReadEventId)
     if( d->unreadMessages && stillUnreadMessagesCount == 0)
     {
         d->unreadMessages = false;
+        qDebug() << "Room" << displayName() << ": no more unread messages";
         emit unreadMessagesChanged(this);
     }
-    qDebug() << "Room" << displayName()
-             << ": still" << stillUnreadMessagesCount << "unread message(s)";
+    if (stillUnreadMessagesCount > 0)
+        qDebug() << "Room" << displayName()
+                 << ": still" << stillUnreadMessagesCount << "unread message(s)";
     return newLastReadEventId.isEmpty() || lastReadEvent(localUser) == newLastReadEventId;
 }
 

--- a/room.h
+++ b/room.h
@@ -32,6 +32,7 @@ namespace QMatrixClient
     class Event;
     class Connection;
     class User;
+    class MemberSorter;
 
     class Room: public QObject
     {
@@ -92,6 +93,8 @@ namespace QMatrixClient
             Q_INVOKABLE int highlightCount() const;
             Q_INVOKABLE void resetHighlightCount();
 
+            MemberSorter memberSorter() const;
+
         public slots:
             void getPreviousContent();
             void userRenamed(User* user, QString oldName);
@@ -137,6 +140,24 @@ namespace QMatrixClient
             void addHistoricalMessageEvents(const Events& events);
 
             void setLastReadEvent(User* user, QString eventId);
+    };
+
+    class MemberSorter
+    {
+        public:
+            MemberSorter(const Room* r) : room(r) { }
+
+            bool operator()(User* u1, User* u2) const;
+
+            template <typename ContT>
+            typename ContT::size_type lowerBoundIndex(const ContT& c,
+                                                      typename ContT::value_type v) const
+            {
+                return  std::lower_bound(c.begin(), c.end(), v, *this) - c.begin();
+            }
+
+        private:
+            const Room* room;
     };
 }
 

--- a/room.h
+++ b/room.h
@@ -132,7 +132,7 @@ namespace QMatrixClient
             virtual void processStateEvents(const Events& events);
             virtual void processEphemeralEvent(Event* event);
 
-            Timeline::const_iterator promoteReadMarker(QString eventId);
+            Timeline::const_iterator promoteReadMarker(User* u, QString eventId);
 
         private:
             class Private;

--- a/room.h
+++ b/room.h
@@ -37,6 +37,7 @@ namespace QMatrixClient
     class Room: public QObject
     {
             Q_OBJECT
+            Q_PROPERTY(QString readMarkerEventId READ readMarkerEventId WRITE markMessagesAsRead NOTIFY readMarkerPromoted)
         public:
             using Timeline = Owning<Events>;
 
@@ -70,19 +71,19 @@ namespace QMatrixClient
             Q_INVOKABLE void updateData(SyncRoomData& data );
             Q_INVOKABLE void setJoinState( JoinState state );
 
-            Q_INVOKABLE QString lastReadEvent(User* user);
+            Q_INVOKABLE QString lastReadEvent(User* user) const;
+            QString readMarkerEventId() const;
             /**
-             * @brief Mark the message at the iterator as read
+             * @brief Mark the event with uptoEventId as read
              *
-             * Marks the message at the iterator as read; also posts a read
-             * receipt to the server either for this message or, if it's from
-             * the local user, for the nearest non-local message before.
+             * Finds in the timeline and marks as read the event with
+             * the specified id; also posts a read receipt to the server either
+             * for this message or, if it's from the local user, for
+             * the nearest non-local message before.
              */
-            Q_INVOKABLE void markMessagesAsRead(Timeline::const_iterator last);
+            Q_INVOKABLE void markMessagesAsRead(QString uptoEventId);
             /**
-             * @brief Mark the most recent message in the timeline as read
-             *
-             * This effectively marks everything in the room as read.
+             * @brief Mark the whole room timeline as read
              */
             Q_INVOKABLE void markMessagesAsRead();
 
@@ -121,6 +122,7 @@ namespace QMatrixClient
             void highlightCountChanged(Room* room);
             void notificationCountChanged(Room* room);
             void lastReadEventChanged(User* user);
+            void readMarkerPromoted();
             void unreadMessagesChanged(Room* room);
 
         protected:
@@ -130,7 +132,7 @@ namespace QMatrixClient
             virtual void processStateEvents(const Events& events);
             virtual void processEphemeralEvent(Event* event);
 
-            bool promoteReadMarker(QString newLastReadEventId);
+            Timeline::const_iterator promoteReadMarker(QString eventId);
 
         private:
             class Private;

--- a/room.h
+++ b/room.h
@@ -85,6 +85,8 @@ namespace QMatrixClient
              */
             Q_INVOKABLE void markMessagesAsRead();
 
+            Q_INVOKABLE bool hasUnreadMessages();
+
             Q_INVOKABLE int notificationCount() const;
             Q_INVOKABLE void resetNotificationCount();
             Q_INVOKABLE int highlightCount() const;
@@ -116,6 +118,7 @@ namespace QMatrixClient
             void highlightCountChanged(Room* room);
             void notificationCountChanged(Room* room);
             void lastReadEventChanged(User* user);
+            void unreadMessagesChanged(Room* room);
 
         protected:
             Connection* connection() const;
@@ -124,7 +127,7 @@ namespace QMatrixClient
             virtual void processStateEvents(const Events& events);
             virtual void processEphemeralEvent(Event* event);
 
-            bool promoteReadMarker(User* user, QString eventId);
+            bool promoteReadMarker(QString newLastReadEventId);
 
         private:
             class Private;


### PR DESCRIPTION
This removes an artificial segregation between `QuaternionRoom` and `QMatrixClient::Room` for the code that deals with read receipts/read marker/unread messages notification.