### PR TITLE
Connection::callApi + Room::getPreviousMessages(limit)

### DIFF
--- a/connection.h
+++ b/connection.h
@@ -69,6 +69,14 @@ namespace QMatrixClient
             Q_INVOKABLE QString token() const;
             Q_INVOKABLE QString accessToken() const;
 
+            template <typename JobT, typename... JobArgTs>
+            JobT* callApi(JobArgTs... jobArgs)
+            {
+                auto job = new JobT(connectionData(), jobArgs...);
+                job->start();
+                return job;
+            }
+
         signals:
             void resolved();
             void connected();

--- a/jobs/postmessagejob.cpp
+++ b/jobs/postmessagejob.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "postmessagejob.h"
-#include "../room.h"
 #include "../connectiondata.h"
 
 #include <QtNetwork/QNetworkReply>
@@ -32,9 +31,10 @@ class PostMessageJob::Private
         QString eventId; // unused yet
 };
 
-PostMessageJob::PostMessageJob(ConnectionData* connection, Room* room, QString type, QString message)
+PostMessageJob::PostMessageJob(ConnectionData* connection, QString roomId,
+                               QString type, QString message)
     : BaseJob(connection, JobHttpType::PostJob, "PostMessageJob",
-              QString("_matrix/client/r0/rooms/%1/send/m.room.message").arg(room->id()),
+              QString("_matrix/client/r0/rooms/%1/send/m.room.message").arg(roomId),
               Query(),
               Data({ { "msgtype", type }, { "body", message } }))
     , d(new Private)

--- a/jobs/postmessagejob.h
+++ b/jobs/postmessagejob.h
@@ -22,11 +22,11 @@
 
 namespace QMatrixClient
 {
-    class Room;
     class PostMessageJob: public BaseJob
     {
         public:
-            PostMessageJob(ConnectionData* connection, Room* room, QString type, QString message);
+            PostMessageJob(ConnectionData* connection, QString roomId,
+                           QString type, QString message);
             virtual ~PostMessageJob();
 
             //bool success();

--- a/jobs/roommessagesjob.cpp
+++ b/jobs/roommessagesjob.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "roommessagesjob.h"
-#include "../room.h"
+#include "../util.h"
 
 #include <QtCore/QJsonArray>
 
@@ -32,12 +32,13 @@ class RoomMessagesJob::Private
         QString end;
 };
 
-RoomMessagesJob::RoomMessagesJob(ConnectionData* data, Room* room, QString from, FetchDirectory dir, int limit)
+RoomMessagesJob::RoomMessagesJob(ConnectionData* data, QString roomId,
+                                 QString from, int limit, FetchDirection dir)
     : BaseJob(data, JobHttpType::GetJob, "RoomMessagesJob",
-              QString("/_matrix/client/r0/rooms/%1/messages").arg(room->id()),
+              QString("/_matrix/client/r0/rooms/%1/messages").arg(roomId),
               Query(
                 { { "from", from }
-                , { "dir", dir == FetchDirectory::Backwards ? "b" : "f" }
+                , { "dir", dir == FetchDirection::Backward ? "b" : "f" }
                 , { "limit", QString::number(limit) }
                 }))
     , d(new Private)

--- a/jobs/roommessagesjob.h
+++ b/jobs/roommessagesjob.h
@@ -24,15 +24,14 @@
 
 namespace QMatrixClient
 {
-    class Room;
-
-    enum class FetchDirectory { Backwards, Forward };
+    enum class FetchDirection { Backward, Forward };
 
     class RoomMessagesJob: public BaseJob
     {
         public:
-            RoomMessagesJob(ConnectionData* data, Room* room, QString from,
-                            FetchDirectory dir = FetchDirectory::Backwards, int limit=10);
+            RoomMessagesJob(ConnectionData* data, QString roomId,
+                            QString from, int limit = 10,
+                            FetchDirection dir = FetchDirection::Backward);
             virtual ~RoomMessagesJob();
 
             Events releaseEvents();

--- a/room.h
+++ b/room.h
@@ -93,7 +93,8 @@ namespace QMatrixClient
             MemberSorter memberSorter() const;
 
         public slots:
-            void getPreviousContent();
+            void postMessage(QString msgType, QString msgContent);
+            void getPreviousContent(int limit = 10);
             void userRenamed(User* user, QString oldName);
 
         signals:


### PR DESCRIPTION
This PR has two improvements:
- `Connection::callApi<>` is a single entry point to create any job on top of `ConnectionData`
- `Room::getPreviousMessages()` now gets an optional parameter `limit`, allowing to specify how many messages to retrieve. This will help in addressing Fxrh/Quaternion#94.

Changes are non-intrusive, setting the review deadline to 1 day.