### PR TITLE
Use special indices instead of iterators into the timeline

### DIFF
--- a/room.h
+++ b/room.h
@@ -39,7 +39,9 @@ namespace QMatrixClient
     class TimelineItem
     {
         public:
-            using index_t = int; // For compatibility with Qt containers
+            // For compatibility with Qt containers, even though we use
+            // a std:: container now
+            using index_t = int;
 
             TimelineItem(Event* e, index_t number) : evt(e), idx(number) { }
 
@@ -51,6 +53,12 @@ namespace QMatrixClient
             std::unique_ptr<Event> evt;
             index_t idx;
     };
+    inline QDebug& operator<<(QDebug& d, const TimelineItem& ti)
+    {
+        QDebugStateSaver dss(d);
+        d.nospace() << "(" << ti.index() << "|" << ti->id() << ")";
+        return d;
+    }
 
     class Room: public QObject
     {
@@ -58,12 +66,12 @@ namespace QMatrixClient
             Q_PROPERTY(QString readMarkerEventId READ readMarkerEventId WRITE markMessagesAsRead NOTIFY readMarkerMoved)
         public:
             using Timeline = std::deque<TimelineItem>;
+            using rev_iter_t = Timeline::const_reverse_iterator;
 
             Room(Connection* connection, QString id);
             virtual ~Room();
 
             Q_INVOKABLE QString id() const;
-            Q_INVOKABLE const Timeline& messageEvents() const;
             Q_INVOKABLE QString name() const;
             Q_INVOKABLE QStringList aliases() const;
             Q_INVOKABLE QString canonicalAlias() const;
@@ -89,6 +97,21 @@ namespace QMatrixClient
             Q_INVOKABLE void updateData(SyncRoomData& data );
             Q_INVOKABLE void setJoinState( JoinState state );
 
+            const Timeline& messageEvents() const;
+            /**
+             * A convenience method returning the read marker to the before-oldest
+             * message
+             */
+            rev_iter_t timelineEdge() const;
+            Q_INVOKABLE TimelineItem::index_t minTimelineIndex() const;
+            Q_INVOKABLE TimelineItem::index_t maxTimelineIndex() const;
+            Q_INVOKABLE bool isValidIndex(TimelineItem::index_t timelineIndex) const;
+
+            rev_iter_t findInTimeline(TimelineItem::index_t index) const;
+            rev_iter_t findInTimeline(QString evtId) const;
+
+            rev_iter_t readMarker(const User* user) const;
+            rev_iter_t readMarker() const;
             QString readMarkerEventId() const;
             /**
              * @brief Mark the event with uptoEventId as read
@@ -98,7 +121,7 @@ namespace QMatrixClient
              * for this message or, if it's from the local user, for
              * the nearest non-local message before. uptoEventId must be non-empty.
              */
-            Q_INVOKABLE void markMessagesAsRead(QString uptoEventId);
+            void markMessagesAsRead(QString uptoEventId);
 
             Q_INVOKABLE bool hasUnreadMessages();
 


### PR DESCRIPTION
This commit fixes a time-bomb in the form of using iterators to store read markers and to keep the events index. The standard turns out to allow deque iterators to become invalidated upon any (even at the deque's ends) insertion. Only pointers and references to deque contents persist through `push_back` and `push_front`; iterators do not. While that code seemingly worked with MinGW on Windows, there's absolutely no guarantee if we move to another platform and/or compiler.
To solve it, I introduced a new `TimelineItem` class that stores a relative index of an event within the timeline. The index can be negative but it is persistent - it doesn't change when we add events to the beginning or to the end of the timeline. Because of that trait it can be used for random access, as in the case of `eventsIndex`, while at the same time providing sequential access and order relation for the case of read markers.
This commit also includes a minor improvement for read receipts processing, as described in the commit message - read receipts for non-existent events are still stored with resolving an event id, so that they can be taken into account later, when/if the event arrives.
Finally, I have renamed the signal `readMarkerPromoted` to `readMarkerMoved` to be able to use it even when we get ability to forcibly move the read marker to whatever event the user wishes.