### PR TITLE
Jobs retry functionality for recoverable errors

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -270,6 +270,16 @@ QString Connection::accessToken() const
     return d->data->accessToken();
 }
 
+SyncJob* Connection::syncJob() const
+{
+    return d->syncJob;
+}
+
+int Connection::millisToReconnect() const
+{
+    return d->syncJob ? d->syncJob->millisToRetry() : 0;
+}
+
 QHash< QString, Room* > Connection::roomMap() const
 {
     return d->roomMap;

--- a/connection.cpp
+++ b/connection.cpp
@@ -175,12 +175,13 @@ void Connection::sync(int timeout)
         d->syncJob = nullptr;
         emit syncDone();
     });
+    connect( job, &SyncJob::retryScheduled, this, &Connection::networkError);
     connect( job, &SyncJob::failure, [=] () {
         d->syncJob = nullptr;
         if (job->error() == BaseJob::ContentAccessError)
             emit loginError(job->errorString());
         else
-            emit connectionError(job->errorString());
+            emit syncError(job->errorString());
     });
 }
 

--- a/connection.h
+++ b/connection.h
@@ -54,6 +54,7 @@ namespace QMatrixClient
             Q_INVOKABLE virtual void logout();
 
             Q_INVOKABLE virtual void sync(int timeout=-1);
+            Q_INVOKABLE virtual void stopSync();
             /** @deprecated Use callApi<PostMessageJob>() or Room::postMessage() instead */
             Q_INVOKABLE virtual void postMessage( Room* room, QString type, QString message );
             /** @deprecated Use callApi<PostReceiptJob>() or Room::postReceipt() instead */

--- a/connection.h
+++ b/connection.h
@@ -94,8 +94,9 @@ namespace QMatrixClient
             void joinedRoom(Room* room);
 
             void loginError(QString error);
-            void connectionError(QString error);
+            void networkError(size_t nextAttempt, int inMilliseconds);
             void resolveError(QString error);
+            void syncError(QString error);
             //void jobError(BaseJob* job);
 
         protected:

--- a/connection.h
+++ b/connection.h
@@ -71,6 +71,8 @@ namespace QMatrixClient
             /** @deprecated Use accessToken() instead. */
             Q_INVOKABLE QString token() const;
             Q_INVOKABLE QString accessToken() const;
+            Q_INVOKABLE SyncJob* syncJob() const;
+            Q_INVOKABLE int millisToReconnect() const;
 
             template <typename JobT, typename... JobArgTs>
             JobT* callApi(JobArgTs... jobArgs)

--- a/jobs/syncjob.cpp
+++ b/jobs/syncjob.cpp
@@ -21,8 +21,6 @@
 #include <QtCore/QJsonArray>
 #include <QtCore/QDebug>
 
-#include "../connectiondata.h"
-
 using namespace QMatrixClient;
 
 class SyncJob::Private
@@ -50,6 +48,8 @@ SyncJob::SyncJob(ConnectionData* connection,
     if( !since.isEmpty() )
         query.addQueryItem("since", since);
     setRequestQuery(query);
+
+    setMaxRetries(std::numeric_limits<int>::max());
 }
 
 SyncJob::~SyncJob()


### PR DESCRIPTION
The commit message has a summary of functionality, and here's a summary of changes:
- `BaseJob::finishJob()` is no more actually finishing the job if the request returned a `NetworkError` or `TimeoutError`, and the limit of retries hasn't been reached; instead, it schedules one more network request with gradually increasing timeouts and retry intervals.
- This addition was a bit against the logic of `BaseJob::abandon()` that actually needs just a small cleanup bit of `finishJob()` - so this bit has been factored out to a new `BaseJob::stop()` method. Now `abandon()` calls `stop()` and then directly `deleteLater()`, instead of `finishJob()`.
- This change made the parameter in `finishJob()` unneeded (all other `finishJob()` call sites except in `abandon()` need to emit result signals), so the parameter was removed.
- `BaseJob::finished()` signal (so far unused) has been renamed to `BaseJob::stopped()` and has a bit different meaning now. Basically, you can get more than one `stopped()` signal per job object, because it's invoked on every failed request, not only on the last one. Other signals are only fired before job dissolution.
- Since `SyncJob` is somewhat special, I decided to let it tolerate all timeout and network errors indefinitely. Hence the maxed-out number of allowed retries.
- `Connection` has gained a couple of accessors that would allow to monitor (and even fine-tune) the retrying process specifically for `SyncJob` from the client code. Expect the corresponding code for Quaternion to be submitted shortly.

The change doesn't alter the existing lib API but alters the behaviour; so I'll give at the usual 7 days here for a possible peer review or at least my own testing.

Closes #26 