### PR TITLE
Don't extend the spec when calculating the display name

### DIFF
--- a/room.cpp
+++ b/room.cpp
@@ -792,12 +792,6 @@ QString Room::Private::calculateDisplayname() const
 
     // 1. Name (from m.room.name)
     if (!name.isEmpty()) {
-        // The below two lines extend the spec. They take care of the case
-        // when there are two rooms with the same name.
-        // The format is unwittingly borrowed from the email address format.
-        if (!canonicalAlias.isEmpty())
-            return name % " <" % canonicalAlias % ">";
-
         return name;
     }
 


### PR DESCRIPTION
Room names conflicts should be handled at the client level, for example
by displaying the canonical alias in a tooltip or in the custom
delegate of the view.

If we extend the display name algorithm at the lib level, we
are just cluttering the display name in the most common scenario
(i.e. when there are no name clashes).