### PR TITLE
Don't discard user display names upon leave membership events

### DIFF
--- a/user.cpp
+++ b/user.cpp
@@ -132,7 +132,7 @@ void User::processEvent(Event* event)
     if( event->type() == EventType::RoomMember )
     {
         RoomMemberEvent* e = static_cast<RoomMemberEvent*>(event);
-        if( d->name != e->displayName() )
+        if( d->name != e->displayName() && e->membership() != MembershipType::Leave)
         {
             const auto oldName = d->name;
             d->name = e->displayName();


### PR DESCRIPTION
Otherwise the following QJsonObject will empty a valid display name in
RoomMemberEvent::fromJson():
```
QJsonObject({"content":{"membership":"leave"},"event_id":"$14905359301189950PoADM:matrix.org","membership":"leave","origin_server_ts":1490535930821,"sender":"@elvisangelaccio:matrix.org","state_key":"@elvisangelaccio:matrix.org","type":"m.room.member","unsigned":{"age":1887090448,"prev_content":{"avatar_url":"mxc://matrix.org/PuDxgBQfeplXbCQFvOGpTEmC","displayname":"eang","membership":"join"},"prev_sender":"@elvisangelaccio:matrix.org","replaces_state":"$14905358091189487gXwtE:matrix.org"}})
```