### PR TITLE
Port to categorized logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ message( STATUS )
 set(libqmatrixclient_SRCS
    connectiondata.cpp
    connection.cpp
+   debug.cpp
    room.cpp
    user.cpp
    state.cpp

--- a/connection.cpp
+++ b/connection.cpp
@@ -74,7 +74,7 @@ Connection::Connection()
 
 Connection::~Connection()
 {
-    qDebug() << "deconstructing connection object for" << d->userId;
+    qCDebug(MAIN) << "deconstructing connection object for" << d->userId;
     delete d;
 }
 
@@ -121,10 +121,10 @@ void Connection::connectWithToken(QString userId, QString token)
     d->isConnected = true;
     d->userId = userId;
     d->data->setToken(token);
-    qDebug() << "Accessing" << d->data->baseUrl()
+    qCDebug(MAIN) << "Accessing" << d->data->baseUrl()
              << "by user" << userId
              << "with the following access token:";
-    qDebug() << token;
+    qCDebug(MAIN) << token;
     emit connected();
 }
 
@@ -307,7 +307,7 @@ Room* Connection::provideRoom(QString id)
 {
     if (id.isEmpty())
     {
-        qDebug() << "Connection::provideRoom() with empty id, doing nothing";
+        qCDebug(MAIN) << "Connection::provideRoom() with empty id, doing nothing";
         return nullptr;
     }
 

--- a/connectiondata.cpp
+++ b/connectiondata.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "connectiondata.h"
+#include "util.h"
 
 #include <QtCore/QDebug>
 #include <QtNetwork/QNetworkAccessManager>
@@ -70,13 +71,13 @@ void ConnectionData::setToken(QString token)
 void ConnectionData::setHost(QString host)
 {
     d->baseUrl.setHost(host);
-    qDebug() << "updated baseUrl to" << d->baseUrl;
+    qCDebug(MAIN) << "updated baseUrl to" << d->baseUrl;
 }
 
 void ConnectionData::setPort(int port)
 {
     d->baseUrl.setPort(port);
-    qDebug() << "updated baseUrl to" << d->baseUrl;
+    qCDebug(MAIN) << "updated baseUrl to" << d->baseUrl;
 }
 
 QString ConnectionData::lastEvent() const

--- a/debug.cpp
+++ b/debug.cpp
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2015 Felix Rohrbach <kde@fxrh.de>
+ * Copyright (C) 2017 Elvis Angelaccio <elvid.angelaccio@kde.org>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,45 +16,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#include "typingevent.h"
 #include "util.h"
 
-#include <QtCore/QJsonArray>
-#include <QtCore/QDebug>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+Q_LOGGING_CATEGORY(MAIN, "libqmatrixclient.main", QtInfoMsg)
+Q_LOGGING_CATEGORY(EVENTS, "libqmatrixclient.events", QtInfoMsg)
+Q_LOGGING_CATEGORY(JOBS, "libqmatrixclient.jobs", QtInfoMsg)
+#else
+Q_LOGGING_CATEGORY(MAIN, "libqmatrixclient.main")
+Q_LOGGING_CATEGORY(EVENTS, "libqmatrixclient.events")
+Q_LOGGING_CATEGORY(JOBS, "libqmatrixclient.jobs")
+#endif
 
-using namespace QMatrixClient;
-
-class TypingEvent::Private
-{
-    public:
-        QStringList users;
-};
-
-TypingEvent::TypingEvent()
-    : Event(EventType::Typing)
-    , d( new Private )
-{
-}
-
-TypingEvent::~TypingEvent()
-{
-    delete d;
-}
-
-QStringList TypingEvent::users()
-{
-    return d->users;
-}
-
-TypingEvent* TypingEvent::fromJson(const QJsonObject& obj)
-{
-    TypingEvent* e = new TypingEvent();
-    e->parseJson(obj);
-    QJsonArray array = obj.value("content").toObject().value("user_ids").toArray();
-    for( const QJsonValue& user: array )
-    {
-        e->d->users << user.toString();
-    }
-    qCDebug(EVENTS) << "Typing:" << e->d->users;
-    return e;
-}

--- a/events/event.cpp
+++ b/events/event.cpp
@@ -124,8 +124,8 @@ bool Event::parseJson(const QJsonObject& obj)
         if (d->id.isEmpty())
         {
             correct = false;
-            qDebug() << "Event: can't find event_id; event dump follows";
-            qDebug() << formatJson << obj;
+            qCDebug(EVENTS) << "Event: can't find event_id; event dump follows";
+            qCDebug(EVENTS) << formatJson << obj;
         }
         if( obj.contains("origin_server_ts") )
         {
@@ -135,8 +135,8 @@ bool Event::parseJson(const QJsonObject& obj)
         else if (d->type != EventType::Unknown)
         {
             correct = false;
-            qDebug() << "Event: can't find ts; event dump follows";
-            qDebug() << formatJson << obj;
+            qCDebug(EVENTS) << "Event: can't find ts; event dump follows";
+            qCDebug(EVENTS) << formatJson << obj;
         }
     }
     return correct;

--- a/events/receiptevent.cpp
+++ b/events/receiptevent.cpp
@@ -34,6 +34,7 @@ Example of a Receipt Event:
 */
 
 #include "receiptevent.h"
+#include "util.h"
 
 #include <QtCore/QJsonArray>
 #include <QtCore/QDebug>
@@ -72,8 +73,8 @@ ReceiptEvent* ReceiptEvent::fromJson(const QJsonObject& obj)
     {
         if (eventIt.key().isEmpty())
         {
-            qWarning() << "ReceiptEvent has an empty event id, skipping";
-            qDebug() << "ReceiptEvent content follows:\n" << contents;
+            qCWarning(EVENTS) << "ReceiptEvent has an empty event id, skipping";
+            qCDebug(EVENTS) << "ReceiptEvent content follows:\n" << contents;
             continue;
         }
         const QJsonObject reads = eventIt.value().toObject().value("m.read").toObject();

--- a/events/roomaliasesevent.cpp
+++ b/events/roomaliasesevent.cpp
@@ -33,6 +33,7 @@
 // }
 
 #include "roomaliasesevent.h"
+#include "util.h"
 
 #include <QtCore/QJsonArray>
 #include <QtCore/QDebug>
@@ -71,6 +72,6 @@ RoomAliasesEvent* RoomAliasesEvent::fromJson(const QJsonObject& obj)
     {
         e->d->aliases << alias.toString();
     }
-    qDebug() << "RoomAliasesEvent:" << e->d->aliases;
+    qCDebug(EVENTS) << "RoomAliasesEvent:" << e->d->aliases;
     return e;
 }

--- a/events/roommemberevent.cpp
+++ b/events/roommemberevent.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "roommemberevent.h"
+#include "util.h"
 
 #include <QtCore/QDebug>
 
@@ -81,7 +82,7 @@ RoomMemberEvent* RoomMemberEvent::fromJson(const QJsonObject& obj)
     else if( membershipString == "ban" )
         e->d->membership = MembershipType::Ban;
     else
-        qDebug() << "Unknown MembershipType: " << membershipString;
+        qCDebug(EVENTS) << "Unknown MembershipType: " << membershipString;
     e->d->avatarUrl = QUrl(content.value("avatar_url").toString());
     return e;
 }

--- a/events/roommessageevent.cpp
+++ b/events/roommessageevent.cpp
@@ -97,8 +97,8 @@ ContentPair makeVideo(const QJsonObject& json)
 
 ContentPair makeUnknown(const QJsonObject& json)
 {
-    qDebug() << "RoomMessageEvent: couldn't resolve msgtype, JSON follows:";
-    qDebug() << json;
+    qCDebug(EVENTS) << "RoomMessageEvent: couldn't resolve msgtype, JSON follows:";
+    qCDebug(EVENTS) << json;
     return { MessageEventType::Unknown, new Base };
 }
 
@@ -110,7 +110,7 @@ RoomMessageEvent* RoomMessageEvent::fromJson(const QJsonObject& obj)
     {
         e->d->userId = obj.value("sender").toString();
     } else {
-        qDebug() << "RoomMessageEvent: user_id not found";
+        qCDebug(EVENTS) << "RoomMessageEvent: user_id not found";
     }
     if( obj.contains("content") )
     {
@@ -135,8 +135,8 @@ RoomMessageEvent* RoomMessageEvent::fromJson(const QJsonObject& obj)
         }
         else
         {
-            qWarning() << "RoomMessageEvent(" << e->id() << "): no body or msgtype";
-            qDebug() << obj;
+            qCWarning(EVENTS) << "RoomMessageEvent(" << e->id() << "): no body or msgtype";
+            qCDebug(EVENTS) << obj;
         }
     }
     return e;

--- a/events/unknownevent.cpp
+++ b/events/unknownevent.cpp
@@ -59,7 +59,7 @@ UnknownEvent* UnknownEvent::fromJson(const QJsonObject& obj)
     e->parseJson(obj);
     e->d->type = obj.value("type").toString();
     e->d->content = QString::fromUtf8(QJsonDocument(obj).toJson());
-    qDebug() << "UnknownEvent, JSON follows:";
-    qDebug() << formatJson << obj;
+    qCDebug(EVENTS) << "UnknownEvent, JSON follows:";
+    qCDebug(EVENTS) << formatJson << obj;
     return e;
 }

--- a/jobs/joinroomjob.cpp
+++ b/jobs/joinroomjob.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "joinroomjob.h"
+#include "util.h"
 
 #include <QtNetwork/QNetworkReply>
 
@@ -56,6 +57,6 @@ BaseJob::Status JoinRoomJob::parseJson(const QJsonDocument& data)
         return Success;
     }
 
-    qDebug() << data;
+    qCDebug(JOBS) << data;
     return { UserDefinedError, "No room_id in the JSON response" };
 }

--- a/jobs/mediathumbnailjob.cpp
+++ b/jobs/mediathumbnailjob.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "mediathumbnailjob.h"
+#include "util.h"
 
 #include <QtCore/QDebug>
 
@@ -55,7 +56,7 @@ BaseJob::Status MediaThumbnailJob::parseReply(QByteArray data)
 {
     if( !d->thumbnail.loadFromData(data) )
     {
-        qDebug() << "MediaThumbnailJob: could not read image data";
+        qCDebug(JOBS) << "MediaThumbnailJob: could not read image data";
     }
     return Success;
 }

--- a/jobs/postmessagejob.cpp
+++ b/jobs/postmessagejob.cpp
@@ -18,6 +18,7 @@
 
 #include "postmessagejob.h"
 #include "../connectiondata.h"
+#include "util.h"
 
 #include <QtNetwork/QNetworkReply>
 
@@ -62,6 +63,6 @@ BaseJob::Status PostMessageJob::parseJson(const QJsonDocument& data)
     if( data.object().contains("event_id") )
         return Success;
 
-    qDebug() << data;
+    qCDebug(JOBS) << data;
     return { UserDefinedError, "No event_id in the JSON response" };
 }

--- a/jobs/roommessagesjob.cpp
+++ b/jobs/roommessagesjob.cpp
@@ -43,7 +43,7 @@ RoomMessagesJob::RoomMessagesJob(ConnectionData* data, QString roomId,
                 }))
     , d(new Private)
 {
-    qDebug() << "Room messages query:" << query().toString(QUrl::PrettyDecoded);
+    qCDebug(JOBS) << "Room messages query:" << query().toString(QUrl::PrettyDecoded);
 }
 
 RoomMessagesJob::~RoomMessagesJob()

--- a/jobs/syncjob.cpp
+++ b/jobs/syncjob.cpp
@@ -123,7 +123,7 @@ SyncRoomData::SyncRoomData(QString roomId_, JoinState joinState_, const QJsonObj
             timeline.fromJson(room_);
             break;
     default:
-        qWarning() << "SyncRoomData: Unknown JoinState value, ignoring:" << int(joinState);
+        qCWarning(JOBS) << "SyncRoomData: Unknown JoinState value, ignoring:" << int(joinState);
     }
 
     QJsonObject timeline = room_.value("timeline").toObject();
@@ -133,5 +133,5 @@ SyncRoomData::SyncRoomData(QString roomId_, JoinState joinState_, const QJsonObj
     QJsonObject unread = room_.value("unread_notifications").toObject();
     highlightCount = unread.value("highlight_count").toInt();
     notificationCount = unread.value("notification_count").toInt();
-    qDebug() << "Highlights: " << highlightCount << " Notifications:" << notificationCount;
+    qCDebug(JOBS) << "Highlights: " << highlightCount << " Notifications:" << notificationCount;
 }

--- a/settings.cpp
+++ b/settings.cpp
@@ -10,7 +10,7 @@ Settings::~Settings()
 
 void Settings::setValue(const QString& key, const QVariant& value)
 {
-//    qDebug() << "Setting" << key << "to" << value;
+//    qCDebug() << "Setting" << key << "to" << value;
     QSettings::setValue(key, value);
 }
 

--- a/user.cpp
+++ b/user.cpp
@@ -22,6 +22,7 @@
 #include "events/event.h"
 #include "events/roommemberevent.h"
 #include "jobs/mediathumbnailjob.h"
+#include "util.h"
 
 #include <QtCore/QTimer>
 #include <QtCore/QDebug>
@@ -97,7 +98,7 @@ QPixmap User::croppedAvatar(int width, int height)
     {
         if( !d->avatarOngoingRequest && d->avatarUrl.isValid() )
         {
-            qDebug() << "Getting avatar for" << id();
+            qCDebug(MAIN) << "Getting avatar for" << id();
             d->requestedSize = size;
             d->avatarOngoingRequest = true;
             QTimer::singleShot(0, this, SLOT(requestAvatar()));

--- a/util.h
+++ b/util.h
@@ -18,7 +18,11 @@
 
 #pragma once
 
-#include <QtCore/QDebug>
+#include <QtCore/QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(EVENTS)
+Q_DECLARE_LOGGING_CATEGORY(JOBS)
+Q_DECLARE_LOGGING_CATEGORY(MAIN)
 
 namespace QMatrixClient
 {
@@ -35,7 +39,7 @@ namespace QMatrixClient
      * Together with the operator<<() helper, the proposed usage is
      * (similar to std:: I/O manipulators):
      *
-     * @example qDebug() << formatJson << json_object; // (QJsonObject, etc.)
+     * @example qCDebug() << formatJson << json_object; // (QJsonObject, etc.)
      */
     inline QDebug formatJson(QDebug debug_object)
     {


### PR DESCRIPTION
This greatly reduces the noise made by quaternion.

To enable full logging, export the following variable:

QT_LOGGING_RULES="libqmatrixclient.*.debug=true"